### PR TITLE
Parameterise types by identifier type

### DIFF
--- a/moniker-derive/Cargo.toml
+++ b/moniker-derive/Cargo.toml
@@ -22,6 +22,7 @@ publish = false
 proc-macro = true
 
 [dependencies]
-quote = "0.5.1"
-syn = "0.13.1"
-synstructure = "0.8.1"
+proc-macro2 ="0.4.6"
+quote = "0.6.3"
+syn = "0.14.2"
+synstructure = "0.9.0"

--- a/moniker-derive/src/lib.rs
+++ b/moniker-derive/src/lib.rs
@@ -1,23 +1,34 @@
-extern crate proc_macro;
+#![recursion_limit = "128"]
 
 extern crate quote;
 extern crate syn;
 #[macro_use]
 extern crate synstructure;
+extern crate proc_macro2;
 
 use synstructure::{BindStyle, Structure};
 
 decl_derive!([BoundTerm] => term_derive);
 
-fn term_derive(mut s: Structure) -> quote::Tokens {
+fn term_derive(mut s: Structure) -> proc_macro2::TokenStream {
     s.bind_with(|_| BindStyle::Ref);
     let term_eq_body = {
         let body = s.variants().iter().fold(quote!(), |acc, v| {
             // Create two sets of bindings, one for the lhs, and another for the rhs
             let mut lhs = v.clone();
             let mut rhs = v.clone();
-            lhs.binding_name(|_, i| syn::Ident::from(format!("__binding_lhs_{}", i)));
-            rhs.binding_name(|_, i| syn::Ident::from(format!("__binding_rhs_{}", i)));
+            lhs.binding_name(|_, i| {
+                syn::Ident::new(
+                    &format!("__binding_lhs_{}", i),
+                    proc_macro2::Span::call_site(),
+                )
+            });
+            rhs.binding_name(|_, i| {
+                syn::Ident::new(
+                    &format!("__binding_rhs_{}", i),
+                    proc_macro2::Span::call_site(),
+                )
+            });
 
             let lhs_pat = lhs.pat();
             let rhs_pat = rhs.pat();
@@ -26,7 +37,7 @@ fn term_derive(mut s: Structure) -> quote::Tokens {
             let arm_body = <_>::zip(lhs.bindings().iter(), rhs.bindings()).fold(
                 quote!(true),
                 |acc, (lhs, rhs)| {
-                    quote! { #acc && ::moniker::BoundTerm::term_eq(#lhs, #rhs) }
+                    quote! { #acc && moniker::BoundTerm::term_eq(#lhs, #rhs) }
                 },
             );
 
@@ -42,52 +53,53 @@ fn term_derive(mut s: Structure) -> quote::Tokens {
 
     s.bind_with(|_| BindStyle::RefMut);
     let close_term_body = s.each(|bi| {
-        quote!{ ::moniker::BoundTerm::close_term(#bi, __state, __pattern); }
+        quote!{ moniker::BoundTerm::close_term(#bi, __state, __pattern); }
     });
     let open_term_body = s.each(|bi| {
-        quote!{ ::moniker::BoundTerm::open_term(#bi, __state, __pattern); }
+        quote!{ moniker::BoundTerm::open_term(#bi, __state, __pattern); }
     });
 
     s.bind_with(|_| BindStyle::Ref);
     let visit_vars_body = s.each(|bi| {
-        quote!{ ::moniker::BoundTerm::visit_vars(#bi, __on_var); }
+        quote!{ moniker::BoundTerm::visit_vars(#bi, __on_var); }
     });
 
     s.bind_with(|_| BindStyle::RefMut);
     let visit_mut_vars_body = s.each(|bi| {
-        quote!{ ::moniker::BoundTerm::visit_mut_vars(#bi, __on_var); }
+        quote!{ moniker::BoundTerm::visit_mut_vars(#bi, __on_var); }
     });
 
-    s.bound_impl(
-        quote!(::moniker::BoundTerm),
-        quote! {
+    s.gen_impl(quote! {
+        extern crate moniker;
+
+        gen impl moniker::BoundTerm<String> for @Self {
             fn term_eq(&self, other: &Self) -> bool {
                 match (self, other) { #term_eq_body }
             }
 
             fn close_term(
                 &mut self,
-                __state: ::moniker::ScopeState,
-                __pattern: &impl ::moniker::BoundPattern,
+                __state: moniker::ScopeState,
+                __pattern: &impl moniker::BoundPattern<String>,
             ) {
                 match *self { #close_term_body }
             }
 
             fn open_term(
                 &mut self,
-                __state: ::moniker::ScopeState,
-                __pattern: &impl ::moniker::BoundPattern,
+                __state: moniker::ScopeState,
+                __pattern: &impl moniker::BoundPattern<String>,
             ) {
                 match *self { #open_term_body }
             }
 
-            fn visit_vars(&self, __on_var: &mut impl FnMut(&::moniker::Var)) {
+            fn visit_vars(&self, __on_var: &mut impl FnMut(&moniker::Var<String>)) {
                 match *self { #visit_vars_body }
             }
 
-            fn visit_mut_vars(&mut self, __on_var: &mut impl FnMut(&mut ::moniker::Var)) {
+            fn visit_mut_vars(&mut self, __on_var: &mut impl FnMut(&mut moniker::Var<String>)) {
                 match *self { #visit_mut_vars_body }
             }
-        },
-    )
+        }
+    })
 }

--- a/moniker/examples/lc.rs
+++ b/moniker/examples/lc.rs
@@ -9,13 +9,13 @@ use std::rc::Rc;
 
 #[derive(Debug, Clone, BoundTerm)]
 pub enum Expr {
-    Var(Var),
-    Lam(Scope<FreeVar, Rc<Expr>>),
+    Var(Var<String>),
+    Lam(Scope<FreeVar<String>, Rc<Expr>>),
     App(Rc<Expr>, Rc<Expr>),
 }
 
 // FIXME: auto-derive this somehow!
-fn subst(expr: &Rc<Expr>, subst_name: &FreeVar, subst_expr: &Rc<Expr>) -> Rc<Expr> {
+fn subst(expr: &Rc<Expr>, subst_name: &FreeVar<String>, subst_expr: &Rc<Expr>) -> Rc<Expr> {
     match **expr {
         Expr::Var(Var::Free(ref n)) if subst_name == n => subst_expr.clone(),
         Expr::Var(_) => expr.clone(),

--- a/moniker/examples/lc_multi.rs
+++ b/moniker/examples/lc_multi.rs
@@ -9,13 +9,13 @@ use std::rc::Rc;
 
 #[derive(Debug, Clone, BoundTerm)]
 pub enum Expr {
-    Var(Var),
-    Lam(Scope<Multi<FreeVar>, Rc<Expr>>),
+    Var(Var<String>),
+    Lam(Scope<Multi<FreeVar<String>>, Rc<Expr>>),
     App(Rc<Expr>, Vec<Rc<Expr>>),
 }
 
 // FIXME: auto-derive this somehow!
-fn substs(expr: &Rc<Expr>, mappings: &[(FreeVar, Rc<Expr>)]) -> Rc<Expr> {
+fn substs(expr: &Rc<Expr>, mappings: &[(FreeVar<String>, Rc<Expr>)]) -> Rc<Expr> {
     match **expr {
         Expr::Var(Var::Free(ref n)) => match mappings.iter().find(|&(n2, _)| n == n2) {
             Some((_, ref subst_expr)) => subst_expr.clone(),

--- a/moniker/examples/lc_nest.rs
+++ b/moniker/examples/lc_nest.rs
@@ -9,14 +9,14 @@ use std::rc::Rc;
 
 #[derive(Debug, Clone, BoundTerm)]
 pub enum Expr {
-    Var(Var),
-    Lam(Scope<FreeVar, Rc<Expr>>),
-    Let(Scope<Nest<(FreeVar, Embed<Rc<Expr>>)>, Rc<Expr>>),
+    Var(Var<String>),
+    Lam(Scope<FreeVar<String>, Rc<Expr>>),
+    Let(Scope<Nest<(FreeVar<String>, Embed<Rc<Expr>>)>, Rc<Expr>>),
     App(Rc<Expr>, Rc<Expr>),
 }
 
 // FIXME: auto-derive this somehow!
-fn substs(expr: &Rc<Expr>, mappings: &[(FreeVar, Rc<Expr>)]) -> Rc<Expr> {
+fn substs(expr: &Rc<Expr>, mappings: &[(FreeVar<String>, Rc<Expr>)]) -> Rc<Expr> {
     match **expr {
         Expr::Var(Var::Free(ref n)) => match mappings.iter().find(|&(n2, _)| n == n2) {
             Some((_, ref subst_expr)) => subst_expr.clone(),

--- a/moniker/examples/lc_rec.rs
+++ b/moniker/examples/lc_rec.rs
@@ -9,14 +9,14 @@ use std::rc::Rc;
 
 #[derive(Debug, Clone, BoundTerm)]
 pub enum Expr {
-    Var(Var),
-    Lam(Scope<FreeVar, Rc<Expr>>),
-    LetRec(Scope<Rec<Multi<(FreeVar, Embed<Rc<Expr>>)>>, Rc<Expr>>),
+    Var(Var<String>),
+    Lam(Scope<FreeVar<String>, Rc<Expr>>),
+    LetRec(Scope<Rec<Multi<(FreeVar<String>, Embed<Rc<Expr>>)>>, Rc<Expr>>),
     App(Rc<Expr>, Rc<Expr>),
 }
 
 // FIXME: auto-derive this somehow!
-fn subst(expr: &Rc<Expr>, subst_name: &FreeVar, subst_expr: &Rc<Expr>) -> Rc<Expr> {
+fn subst(expr: &Rc<Expr>, subst_name: &FreeVar<String>, subst_expr: &Rc<Expr>) -> Rc<Expr> {
     match **expr {
         Expr::Var(Var::Free(ref n)) if subst_name == n => subst_expr.clone(),
         Expr::Var(_) => expr.clone(),

--- a/moniker/examples/stlc.rs
+++ b/moniker/examples/stlc.rs
@@ -11,7 +11,7 @@ use im::HashMap;
 use moniker::{BoundTerm, Embed, FreeVar, Scope, Var};
 use std::rc::Rc;
 
-type Context = HashMap<FreeVar, Rc<Type>>;
+type Context = HashMap<FreeVar<String>, Rc<Type>>;
 
 #[derive(Debug, Clone, BoundTerm)]
 pub enum Type {
@@ -22,13 +22,13 @@ pub enum Type {
 #[derive(Debug, Clone, BoundTerm)]
 pub enum Expr {
     Ann(Rc<Expr>, Rc<Type>),
-    Var(Var),
-    Lam(Scope<(FreeVar, Embed<Option<Rc<Type>>>), Rc<Expr>>),
+    Var(Var<String>),
+    Lam(Scope<(FreeVar<String>, Embed<Option<Rc<Type>>>), Rc<Expr>>),
     App(Rc<Expr>, Rc<Expr>),
 }
 
 // FIXME: auto-derive this somehow!
-fn subst(expr: &Rc<Expr>, subst_name: &FreeVar, subst_expr: &Rc<Expr>) -> Rc<Expr> {
+fn subst(expr: &Rc<Expr>, subst_name: &FreeVar<String>, subst_expr: &Rc<Expr>) -> Rc<Expr> {
     match **expr {
         Expr::Ann(ref expr, ref ty) => {
             Rc::new(Expr::Ann(subst(expr, subst_name, subst_expr), ty.clone()))

--- a/moniker/src/embed.rs
+++ b/moniker/src/embed.rs
@@ -5,33 +5,33 @@ use var::{BoundVar, FreeVar};
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct Embed<T>(pub T);
 
-impl<T> BoundPattern for Embed<T>
+impl<Ident, T> BoundPattern<Ident> for Embed<T>
 where
-    T: BoundTerm,
+    T: BoundTerm<Ident>,
 {
     fn pattern_eq(&self, other: &Embed<T>) -> bool {
         T::term_eq(&self.0, &other.0)
     }
 
-    fn freshen(&mut self) -> PatternSubsts<FreeVar> {
+    fn freshen(&mut self) -> PatternSubsts<FreeVar<Ident>> {
         PatternSubsts::new(Vec::new())
     }
 
-    fn rename(&mut self, _perm: &PatternSubsts<FreeVar>) {}
+    fn rename(&mut self, _perm: &PatternSubsts<FreeVar<Ident>>) {}
 
-    fn close_pattern(&mut self, state: ScopeState, pattern: &impl BoundPattern) {
+    fn close_pattern(&mut self, state: ScopeState, pattern: &impl BoundPattern<Ident>) {
         self.0.close_term(state, pattern);
     }
 
-    fn open_pattern(&mut self, state: ScopeState, pattern: &impl BoundPattern) {
+    fn open_pattern(&mut self, state: ScopeState, pattern: &impl BoundPattern<Ident>) {
         self.0.open_term(state, pattern);
     }
 
-    fn on_free(&self, _state: ScopeState, _name: &FreeVar) -> Option<BoundVar> {
+    fn on_free(&self, _state: ScopeState, _name: &FreeVar<Ident>) -> Option<BoundVar> {
         None
     }
 
-    fn on_bound(&self, _state: ScopeState, _name: BoundVar) -> Option<FreeVar> {
+    fn on_bound(&self, _state: ScopeState, _name: BoundVar) -> Option<FreeVar<Ident>> {
         None
     }
 }

--- a/moniker/src/ignore.rs
+++ b/moniker/src/ignore.rs
@@ -8,28 +8,28 @@ use var::{BoundVar, FreeVar};
 #[derive(Debug, Copy, Clone, PartialEq, Eq, Hash, Default)]
 pub struct Ignore<T>(pub T);
 
-impl<T> BoundTerm for Ignore<T> {
+impl<Ident, T> BoundTerm<Ident> for Ignore<T> {
     fn term_eq(&self, _: &Ignore<T>) -> bool {
         true
     }
 }
 
-impl<T> BoundPattern for Ignore<T> {
+impl<Ident, T> BoundPattern<Ident> for Ignore<T> {
     fn pattern_eq(&self, _: &Ignore<T>) -> bool {
         true
     }
 
-    fn freshen(&mut self) -> PatternSubsts<FreeVar> {
+    fn freshen(&mut self) -> PatternSubsts<FreeVar<Ident>> {
         PatternSubsts::new(Vec::new())
     }
 
-    fn rename(&mut self, _: &PatternSubsts<FreeVar>) {}
+    fn rename(&mut self, _: &PatternSubsts<FreeVar<Ident>>) {}
 
-    fn on_free(&self, _: ScopeState, _: &FreeVar) -> Option<BoundVar> {
+    fn on_free(&self, _: ScopeState, _: &FreeVar<Ident>) -> Option<BoundVar> {
         None
     }
 
-    fn on_bound(&self, _: ScopeState, _: BoundVar) -> Option<FreeVar> {
+    fn on_bound(&self, _: ScopeState, _: BoundVar) -> Option<FreeVar<Ident>> {
         None
     }
 }

--- a/moniker/src/lib.rs
+++ b/moniker/src/lib.rs
@@ -80,4 +80,4 @@ pub use self::multi::Multi;
 pub use self::nest::Nest;
 pub use self::rec::Rec;
 pub use self::scope::Scope;
-pub use self::var::{BoundVar, DebruijnIndex, FreeVar, GenId, Ident, PatternIndex, Var};
+pub use self::var::{BoundVar, DebruijnIndex, FreeVar, GenId, PatternIndex, Var};

--- a/moniker/src/rec.rs
+++ b/moniker/src/rec.rs
@@ -7,52 +7,55 @@ pub struct Rec<P> {
     pub unsafe_pattern: P,
 }
 
-impl<P> Rec<P>
-where
-    P: BoundPattern + Clone,
-{
-    pub fn new(pattern: &P) -> Rec<P> {
+impl<P> Rec<P> {
+    pub fn new<Ident>(pattern: &P) -> Rec<P>
+    where
+        P: BoundPattern<Ident> + Clone,
+    {
         let mut unsafe_pattern = pattern.clone();
         unsafe_pattern.close_pattern(ScopeState::new(), pattern);
         Rec { unsafe_pattern }
     }
 
-    pub fn unrec(&self) -> P {
+    pub fn unrec<Ident>(&self) -> P
+    where
+        P: BoundPattern<Ident> + Clone,
+    {
         let mut pattern = self.unsafe_pattern.clone();
         pattern.open_pattern(ScopeState::new(), self);
         pattern
     }
 }
 
-impl<P> BoundPattern for Rec<P>
+impl<Ident, P> BoundPattern<Ident> for Rec<P>
 where
-    P: BoundPattern,
+    P: BoundPattern<Ident>,
 {
     fn pattern_eq(&self, other: &Rec<P>) -> bool {
         P::pattern_eq(&self.unsafe_pattern, &other.unsafe_pattern)
     }
 
-    fn freshen(&mut self) -> PatternSubsts<FreeVar> {
+    fn freshen(&mut self) -> PatternSubsts<FreeVar<Ident>> {
         self.unsafe_pattern.freshen()
     }
 
-    fn rename(&mut self, perm: &PatternSubsts<FreeVar>) {
+    fn rename(&mut self, perm: &PatternSubsts<FreeVar<Ident>>) {
         self.unsafe_pattern.rename(perm)
     }
 
-    fn close_pattern(&mut self, state: ScopeState, pattern: &impl BoundPattern) {
+    fn close_pattern(&mut self, state: ScopeState, pattern: &impl BoundPattern<Ident>) {
         self.unsafe_pattern.close_pattern(state, pattern);
     }
 
-    fn open_pattern(&mut self, state: ScopeState, pattern: &impl BoundPattern) {
+    fn open_pattern(&mut self, state: ScopeState, pattern: &impl BoundPattern<Ident>) {
         self.unsafe_pattern.open_pattern(state, pattern);
     }
 
-    fn on_free(&self, state: ScopeState, name: &FreeVar) -> Option<BoundVar> {
+    fn on_free(&self, state: ScopeState, name: &FreeVar<Ident>) -> Option<BoundVar> {
         self.unsafe_pattern.on_free(state, name)
     }
 
-    fn on_bound(&self, state: ScopeState, name: BoundVar) -> Option<FreeVar> {
+    fn on_bound(&self, state: ScopeState, name: BoundVar) -> Option<FreeVar<Ident>> {
         self.unsafe_pattern.on_bound(state, name)
     }
 }

--- a/moniker/src/var.rs
+++ b/moniker/src/var.rs
@@ -1,38 +1,5 @@
 use std::fmt;
 
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
-pub struct Ident(String);
-
-impl<'a> From<&'a str> for Ident {
-    fn from(src: &'a str) -> Ident {
-        Ident(String::from(src))
-    }
-}
-
-impl From<String> for Ident {
-    fn from(src: String) -> Ident {
-        Ident(src)
-    }
-}
-
-impl PartialEq<str> for Ident {
-    fn eq(&self, other: &str) -> bool {
-        self.0 == other
-    }
-}
-
-impl PartialEq<String> for Ident {
-    fn eq(&self, other: &String) -> bool {
-        self.0 == *other
-    }
-}
-
-impl fmt::Display for Ident {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.0)
-    }
-}
-
 /// A generated id
 #[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
 pub struct GenId(u32);
@@ -59,7 +26,7 @@ impl fmt::Display for GenId {
 
 /// A free variable
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
-pub enum FreeVar {
+pub enum FreeVar<Ident> {
     /// Names originating from user input
     User(Ident),
     /// A generated id with an optional string that may have come from user
@@ -67,10 +34,10 @@ pub enum FreeVar {
     Gen(GenId, Option<Ident>),
 }
 
-impl FreeVar {
+impl<Ident> FreeVar<Ident> {
     /// Create a name from a human-readable string
-    pub fn user<S: Into<Ident>>(name: S) -> FreeVar {
-        FreeVar::User(name.into())
+    pub fn user<T: Into<Ident>>(ident: T) -> FreeVar<Ident> {
+        FreeVar::User(ident.into())
     }
 
     pub fn ident(&self) -> Option<&Ident> {
@@ -81,31 +48,13 @@ impl FreeVar {
     }
 }
 
-impl From<GenId> for FreeVar {
-    fn from(src: GenId) -> FreeVar {
+impl<Ident> From<GenId> for FreeVar<Ident> {
+    fn from(src: GenId) -> FreeVar<Ident> {
         FreeVar::Gen(src, None)
     }
 }
 
-impl PartialEq<str> for FreeVar {
-    fn eq(&self, other: &str) -> bool {
-        match *self {
-            FreeVar::User(ref name) => name == other,
-            FreeVar::Gen(_, _) => false,
-        }
-    }
-}
-
-impl PartialEq<String> for FreeVar {
-    fn eq(&self, other: &String) -> bool {
-        match *self {
-            FreeVar::User(ref name) => name == other,
-            FreeVar::Gen(_, _) => false,
-        }
-    }
-}
-
-impl fmt::Display for FreeVar {
+impl<Ident: fmt::Display> fmt::Display for FreeVar<Ident> {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match *self {
             FreeVar::User(ref name) => write!(f, "{}", name),
@@ -162,32 +111,14 @@ impl fmt::Display for BoundVar {
 
 /// A variable that can either be free or bound
 #[derive(Debug, Clone, PartialEq, Eq)]
-pub enum Var {
+pub enum Var<Ident> {
     /// A free variable
-    Free(FreeVar),
+    Free(FreeVar<Ident>),
     /// A variable that is bound by a lambda or pi binder
     Bound(BoundVar, Option<Ident>),
 }
 
-impl PartialEq<str> for Var {
-    fn eq(&self, other: &str) -> bool {
-        match *self {
-            Var::Free(ref name) => name == other,
-            Var::Bound(_, _) => false,
-        }
-    }
-}
-
-impl PartialEq<String> for Var {
-    fn eq(&self, other: &String) -> bool {
-        match *self {
-            Var::Free(ref name) => name == other,
-            Var::Bound(_, _) => false,
-        }
-    }
-}
-
-impl fmt::Display for Var {
+impl<Ident: fmt::Display> fmt::Display for Var<Ident> {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match *self {
             Var::Bound(bound, None) => write!(f, "@{}", bound),


### PR DESCRIPTION
This should allow users to customise the underlying string type, using an interner if they so choose. Closes #3.