### PR TITLE
Use wrapper types in examples

### DIFF
--- a/moniker/examples/lc.rs
+++ b/moniker/examples/lc.rs
@@ -13,37 +13,53 @@ pub enum Expr {
     /// Variables
     Var(Var<String>),
     /// Lambda expressions
-    Lam(Scope<FreeVar<String>, Rc<Expr>>),
+    Lam(Scope<FreeVar<String>, RcExpr>),
     /// Function application
-    App(Rc<Expr>, Rc<Expr>),
+    App(RcExpr, RcExpr),
 }
 
-// FIXME: auto-derive this somehow!
-fn subst(expr: &Rc<Expr>, name: &FreeVar<String>, replacement: &Rc<Expr>) -> Rc<Expr> {
-    match **expr {
-        Expr::Var(Var::Free(ref n)) if name == n => replacement.clone(),
-        Expr::Var(_) => expr.clone(),
-        Expr::Lam(ref scope) => Rc::new(Expr::Lam(Scope {
-            unsafe_pattern: scope.unsafe_pattern.clone(),
-            unsafe_body: subst(&scope.unsafe_body, name, replacement),
-        })),
-        Expr::App(ref fun, ref arg) => Rc::new(Expr::App(
-            subst(fun, name, replacement),
-            subst(arg, name, replacement),
-        )),
+/// Reference counted expressions
+#[derive(Debug, Clone, BoundTerm)]
+pub struct RcExpr {
+    pub inner: Rc<Expr>,
+}
+
+impl From<Expr> for RcExpr {
+    fn from(src: Expr) -> RcExpr {
+        RcExpr {
+            inner: Rc::new(src),
+        }
+    }
+}
+
+impl RcExpr {
+    // FIXME: auto-derive this somehow!
+    fn subst(&self, name: &FreeVar<String>, replacement: &RcExpr) -> RcExpr {
+        match *self.inner {
+            Expr::Var(Var::Free(ref n)) if name == n => replacement.clone(),
+            Expr::Var(_) => self.clone(),
+            Expr::Lam(ref scope) => RcExpr::from(Expr::Lam(Scope {
+                unsafe_pattern: scope.unsafe_pattern.clone(),
+                unsafe_body: scope.unsafe_body.subst(name, replacement),
+            })),
+            Expr::App(ref fun, ref arg) => RcExpr::from(Expr::App(
+                fun.subst(name, replacement),
+                arg.subst(name, replacement),
+            )),
+        }
     }
 }
 
 /// Evaluate an expression into its normal form
-pub fn eval(expr: &Rc<Expr>) -> Rc<Expr> {
-    match **expr {
+pub fn eval(expr: &RcExpr) -> RcExpr {
+    match *expr.inner {
         Expr::Var(Var::Free(_)) => expr.clone(),
         Expr::Var(Var::Bound(ref name, _)) => panic!("encountered a bound variable: {:?}", name),
         Expr::Lam(_) => expr.clone(),
-        Expr::App(ref fun, ref arg) => match *eval(fun) {
+        Expr::App(ref fun, ref arg) => match *eval(fun).inner {
             Expr::Lam(ref scope) => {
                 let (name, body) = scope.clone().unbind();
-                eval(&subst(&body, &name, &eval(arg)))
+                eval(&body.subst(&name, &eval(arg)))
             },
             _ => expr.clone(),
         },
@@ -53,17 +69,17 @@ pub fn eval(expr: &Rc<Expr>) -> Rc<Expr> {
 #[test]
 fn test_eval() {
     // expr = (\x -> x) y
-    let expr = Rc::new(Expr::App(
-        Rc::new(Expr::Lam(Scope::new(
+    let expr = RcExpr::from(Expr::App(
+        RcExpr::from(Expr::Lam(Scope::new(
             FreeVar::user("x"),
-            Rc::new(Expr::Var(Var::Free(FreeVar::user("x")))),
+            RcExpr::from(Expr::Var(Var::Free(FreeVar::user("x")))),
         ))),
-        Rc::new(Expr::Var(Var::Free(FreeVar::user("y")))),
+        RcExpr::from(Expr::Var(Var::Free(FreeVar::user("y")))),
     ));
 
     assert_term_eq!(
         eval(&expr),
-        Rc::new(Expr::Var(Var::Free(FreeVar::user("y")))),
+        RcExpr::from(Expr::Var(Var::Free(FreeVar::user("y")))),
     );
 }
 

--- a/moniker/examples/lc_let.rs
+++ b/moniker/examples/lc_let.rs
@@ -13,52 +13,70 @@ pub enum Expr {
     /// Variables
     Var(Var<String>),
     /// Lambda expressions
-    Lam(Scope<FreeVar<String>, Rc<Expr>>),
+    Lam(Scope<FreeVar<String>, RcExpr>),
     /// Function application
-    App(Rc<Expr>, Rc<Expr>),
+    App(RcExpr, RcExpr),
     /// Nested let bindings
-    Let(Scope<Nest<(FreeVar<String>, Embed<Rc<Expr>>)>, Rc<Expr>>),
+    Let(Scope<Nest<(FreeVar<String>, Embed<RcExpr>)>, RcExpr>),
 }
 
-// FIXME: auto-derive this somehow!
-fn substs(expr: &Rc<Expr>, mappings: &[(FreeVar<String>, Rc<Expr>)]) -> Rc<Expr> {
-    match **expr {
-        Expr::Var(Var::Free(ref n)) => match mappings.iter().find(|&(n2, _)| n == n2) {
-            Some((_, ref subst_expr)) => subst_expr.clone(),
-            None => expr.clone(),
-        },
-        Expr::Var(_) => expr.clone(),
-        Expr::Lam(ref scope) => Rc::new(Expr::Lam(Scope {
-            unsafe_pattern: scope.unsafe_pattern.clone(),
-            unsafe_body: substs(&scope.unsafe_body, mappings),
-        })),
-        Expr::App(ref fun, ref arg) => {
-            Rc::new(Expr::App(substs(fun, mappings), substs(arg, mappings)))
-        },
-        Expr::Let(ref scope) => Rc::new(Expr::Let(Scope {
-            unsafe_pattern: Nest {
-                unsafe_patterns: scope
-                    .unsafe_pattern
-                    .unsafe_patterns
-                    .iter()
-                    .map(|&(ref n, Embed(ref value))| (n.clone(), Embed(substs(value, mappings))))
-                    .collect(),
+/// Reference counted expressions
+#[derive(Debug, Clone, BoundTerm)]
+pub struct RcExpr {
+    pub inner: Rc<Expr>,
+}
+
+impl From<Expr> for RcExpr {
+    fn from(src: Expr) -> RcExpr {
+        RcExpr {
+            inner: Rc::new(src),
+        }
+    }
+}
+
+impl RcExpr {
+    // FIXME: auto-derive this somehow!
+    fn substs(&self, mappings: &[(FreeVar<String>, RcExpr)]) -> RcExpr {
+        match *self.inner {
+            Expr::Var(Var::Free(ref n)) => match mappings.iter().find(|&(n2, _)| n == n2) {
+                Some((_, ref subst_expr)) => subst_expr.clone(),
+                None => self.clone(),
             },
-            unsafe_body: substs(&scope.unsafe_body, mappings),
-        })),
+            Expr::Var(_) => self.clone(),
+            Expr::Lam(ref scope) => RcExpr::from(Expr::Lam(Scope {
+                unsafe_pattern: scope.unsafe_pattern.clone(),
+                unsafe_body: scope.unsafe_body.substs(mappings),
+            })),
+            Expr::App(ref fun, ref arg) => {
+                RcExpr::from(Expr::App(fun.substs(mappings), arg.substs(mappings)))
+            },
+            Expr::Let(ref scope) => RcExpr::from(Expr::Let(Scope {
+                unsafe_pattern: Nest {
+                    unsafe_patterns: scope
+                        .unsafe_pattern
+                        .unsafe_patterns
+                        .iter()
+                        .map(|&(ref n, Embed(ref value))| {
+                            (n.clone(), Embed(value.substs(mappings)))
+                        })
+                        .collect(),
+                },
+                unsafe_body: scope.unsafe_body.substs(mappings),
+            })),
+        }
     }
 }
 
 /// Evaluate an expression into its normal form
-pub fn eval(expr: &Rc<Expr>) -> Rc<Expr> {
-    match **expr {
+pub fn eval(expr: &RcExpr) -> RcExpr {
+    match *expr.inner {
         Expr::Var(Var::Free(_)) => expr.clone(),
         Expr::Var(Var::Bound(ref name, _)) => panic!("encountered a bound variable: {:?}", name),
         Expr::Lam(_) => expr.clone(),
-        Expr::App(ref fun, ref arg) => match *eval(fun) {
+        Expr::App(ref fun, ref arg) => match *eval(fun).inner {
             Expr::Lam(ref scope) => {
                 let (name, body) = scope.clone().unbind();
-                eval(&substs(&body, &[(name, eval(arg))]))
+                eval(&body.substs(&[(name, eval(arg))]))
             },
             _ => expr.clone(),
         },
@@ -67,11 +85,11 @@ pub fn eval(expr: &Rc<Expr>) -> Rc<Expr> {
             let mut mappings = Vec::with_capacity(bindings.unsafe_patterns.len());
 
             for (name, Embed(value)) in bindings.unnest() {
-                let value = eval(&substs(&value, &mappings));
+                let value = eval(&value.substs(&mappings));
                 mappings.push((name, value));
             }
 
-            eval(&substs(&body, &mappings))
+            eval(&body.substs(&mappings))
         },
     }
 }
@@ -79,17 +97,17 @@ pub fn eval(expr: &Rc<Expr>) -> Rc<Expr> {
 #[test]
 fn test_eval() {
     // expr = (\x -> x) y
-    let expr = Rc::new(Expr::App(
-        Rc::new(Expr::Lam(Scope::new(
+    let expr = RcExpr::from(Expr::App(
+        RcExpr::from(Expr::Lam(Scope::new(
             FreeVar::user("x"),
-            Rc::new(Expr::Var(Var::Free(FreeVar::user("x")))),
+            RcExpr::from(Expr::Var(Var::Free(FreeVar::user("x")))),
         ))),
-        Rc::new(Expr::Var(Var::Free(FreeVar::user("y")))),
+        RcExpr::from(Expr::Var(Var::Free(FreeVar::user("y")))),
     ));
 
     assert_term_eq!(
         eval(&expr),
-        Rc::new(Expr::Var(Var::Free(FreeVar::user("y")))),
+        RcExpr::from(Expr::Var(Var::Free(FreeVar::user("y")))),
     );
 }
 
@@ -100,33 +118,33 @@ fn test_eval_let() {
     //          foo =  y
     //          bar = id foo
     //      in bar
-    let expr = Rc::new(Expr::Let(Scope::new(
+    let expr = RcExpr::from(Expr::Let(Scope::new(
         Nest::new(vec![
             (
                 FreeVar::user("id"),
-                Embed(Rc::new(Expr::Lam(Scope::new(
+                Embed(RcExpr::from(Expr::Lam(Scope::new(
                     FreeVar::user("x"),
-                    Rc::new(Expr::Var(Var::Free(FreeVar::user("x")))),
+                    RcExpr::from(Expr::Var(Var::Free(FreeVar::user("x")))),
                 )))),
             ),
             (
                 FreeVar::user("foo"),
-                Embed(Rc::new(Expr::Var(Var::Free(FreeVar::user("y"))))),
+                Embed(RcExpr::from(Expr::Var(Var::Free(FreeVar::user("y"))))),
             ),
             (
                 FreeVar::user("bar"),
-                Embed(Rc::new(Expr::App(
-                    Rc::new(Expr::Var(Var::Free(FreeVar::user("id")))),
-                    Rc::new(Expr::Var(Var::Free(FreeVar::user("foo")))),
+                Embed(RcExpr::from(Expr::App(
+                    RcExpr::from(Expr::Var(Var::Free(FreeVar::user("id")))),
+                    RcExpr::from(Expr::Var(Var::Free(FreeVar::user("foo")))),
                 ))),
             ),
         ]),
-        Rc::new(Expr::Var(Var::Free(FreeVar::user("bar")))),
+        RcExpr::from(Expr::Var(Var::Free(FreeVar::user("bar")))),
     )));
 
     assert_term_eq!(
         eval(&expr),
-        Rc::new(Expr::Var(Var::Free(FreeVar::user("y")))),
+        RcExpr::from(Expr::Var(Var::Free(FreeVar::user("y")))),
     );
 }
 

--- a/moniker/examples/lc_letrec.rs
+++ b/moniker/examples/lc_letrec.rs
@@ -13,56 +13,72 @@ pub enum Expr {
     /// Variables
     Var(Var<String>),
     /// Lambda expressions
-    Lam(Scope<FreeVar<String>, Rc<Expr>>),
+    Lam(Scope<FreeVar<String>, RcExpr>),
     /// Function application
-    App(Rc<Expr>, Rc<Expr>),
+    App(RcExpr, RcExpr),
     /// Mutually recursive let bindings
-    LetRec(Scope<Rec<Multi<(FreeVar<String>, Embed<Rc<Expr>>)>>, Rc<Expr>>),
+    LetRec(Scope<Rec<Multi<(FreeVar<String>, Embed<RcExpr>)>>, RcExpr>),
 }
 
-// FIXME: auto-derive this somehow!
-fn subst(expr: &Rc<Expr>, name: &FreeVar<String>, replacement: &Rc<Expr>) -> Rc<Expr> {
-    match **expr {
-        Expr::Var(Var::Free(ref n)) if name == n => replacement.clone(),
-        Expr::Var(_) => expr.clone(),
-        Expr::Lam(ref scope) => Rc::new(Expr::Lam(Scope {
-            unsafe_pattern: scope.unsafe_pattern.clone(),
-            unsafe_body: subst(&scope.unsafe_body, name, replacement),
-        })),
-        Expr::App(ref fun, ref arg) => Rc::new(Expr::App(
-            subst(fun, name, replacement),
-            subst(arg, name, replacement),
-        )),
-        Expr::LetRec(ref scope) => {
-            let Multi(ref bindings) = scope.unsafe_pattern.unsafe_pattern;
+/// Reference counted expressions
+#[derive(Debug, Clone, BoundTerm)]
+pub struct RcExpr {
+    pub inner: Rc<Expr>,
+}
 
-            Rc::new(Expr::LetRec(Scope {
-                unsafe_pattern: Rec {
-                    unsafe_pattern: Multi(
-                        bindings
-                            .iter()
-                            .map(|&(ref n, Embed(ref value))| {
-                                (n.clone(), Embed(subst(value, name, replacement)))
-                            })
-                            .collect(),
-                    ),
-                },
-                unsafe_body: subst(&scope.unsafe_body, name, replacement),
-            }))
-        },
+impl From<Expr> for RcExpr {
+    fn from(src: Expr) -> RcExpr {
+        RcExpr {
+            inner: Rc::new(src),
+        }
+    }
+}
+
+impl RcExpr {
+    // FIXME: auto-derive this somehow!
+    fn subst(&self, name: &FreeVar<String>, replacement: &RcExpr) -> RcExpr {
+        match *self.inner {
+            Expr::Var(Var::Free(ref n)) if name == n => replacement.clone(),
+            Expr::Var(_) => self.clone(),
+            Expr::Lam(ref scope) => RcExpr::from(Expr::Lam(Scope {
+                unsafe_pattern: scope.unsafe_pattern.clone(),
+                unsafe_body: scope.unsafe_body.subst(name, replacement),
+            })),
+            Expr::App(ref fun, ref arg) => RcExpr::from(Expr::App(
+                fun.subst(name, replacement),
+                arg.subst(name, replacement),
+            )),
+            Expr::LetRec(ref scope) => {
+                let Multi(ref bindings) = scope.unsafe_pattern.unsafe_pattern;
+
+                RcExpr::from(Expr::LetRec(Scope {
+                    unsafe_pattern: Rec {
+                        unsafe_pattern: Multi(
+                            bindings
+                                .iter()
+                                .map(|&(ref n, Embed(ref value))| {
+                                    (n.clone(), Embed(value.subst(name, replacement)))
+                                })
+                                .collect(),
+                        ),
+                    },
+                    unsafe_body: scope.unsafe_body.subst(name, replacement),
+                }))
+            },
+        }
     }
 }
 
 /// Evaluate an expression into its normal form
-pub fn eval(expr: &Rc<Expr>) -> Rc<Expr> {
-    match **expr {
+pub fn eval(expr: &RcExpr) -> RcExpr {
+    match *expr.inner {
         Expr::Var(Var::Free(_)) => expr.clone(),
         Expr::Var(Var::Bound(ref name, _)) => panic!("encountered a bound variable: {:?}", name),
         Expr::Lam(_) => expr.clone(),
-        Expr::App(ref fun, ref arg) => match *eval(fun) {
+        Expr::App(ref fun, ref arg) => match *eval(fun).inner {
             Expr::Lam(ref scope) => {
                 let (name, body) = scope.clone().unbind();
-                eval(&subst(&body, &name, &eval(arg)))
+                eval(&body.subst(&name, &eval(arg)))
             },
             _ => expr.clone(),
         },
@@ -72,14 +88,14 @@ pub fn eval(expr: &Rc<Expr>) -> Rc<Expr> {
 
             // substitute the variable definitions all (once) throughout the body
             for &(ref name, Embed(ref binding)) in &bindings {
-                body = subst(&body, name, binding);
+                body = body.subst(name, binding);
             }
 
             // garbage collect, if possible
             // FIXME: `free_vars` is slow! We probably want this to be faster - see issue #10
             let fvs = body.free_vars();
             if bindings.iter().any(|&(ref name, _)| fvs.contains(name)) {
-                Rc::new(Expr::LetRec(Scope::new(Rec::new(&Multi(bindings)), body)))
+                RcExpr::from(Expr::LetRec(Scope::new(Rec::new(&Multi(bindings)), body)))
             } else {
                 eval(&body)
             }
@@ -90,17 +106,17 @@ pub fn eval(expr: &Rc<Expr>) -> Rc<Expr> {
 #[test]
 fn test_eval() {
     // expr = (\x -> x) y
-    let expr = Rc::new(Expr::App(
-        Rc::new(Expr::Lam(Scope::new(
+    let expr = RcExpr::from(Expr::App(
+        RcExpr::from(Expr::Lam(Scope::new(
             FreeVar::user("x"),
-            Rc::new(Expr::Var(Var::Free(FreeVar::user("x")))),
+            RcExpr::from(Expr::Var(Var::Free(FreeVar::user("x")))),
         ))),
-        Rc::new(Expr::Var(Var::Free(FreeVar::user("y")))),
+        RcExpr::from(Expr::Var(Var::Free(FreeVar::user("y")))),
     ));
 
     assert_term_eq!(
         eval(&expr),
-        Rc::new(Expr::Var(Var::Free(FreeVar::user("y")))),
+        RcExpr::from(Expr::Var(Var::Free(FreeVar::user("y")))),
     );
 }
 
@@ -112,29 +128,29 @@ fn test_eval_let_rec() {
     //          id =  \x -> x
     //      in
     //          test
-    let expr = Rc::new(Expr::LetRec(Scope::new(
+    let expr = RcExpr::from(Expr::LetRec(Scope::new(
         Rec::new(&Multi(vec![
             (
                 FreeVar::user("test"),
-                Embed(Rc::new(Expr::App(
-                    Rc::new(Expr::Var(Var::Free(FreeVar::user("id")))),
-                    Rc::new(Expr::Var(Var::Free(FreeVar::user("x")))),
+                Embed(RcExpr::from(Expr::App(
+                    RcExpr::from(Expr::Var(Var::Free(FreeVar::user("id")))),
+                    RcExpr::from(Expr::Var(Var::Free(FreeVar::user("x")))),
                 ))),
             ),
             (
                 FreeVar::user("id"),
-                Embed(Rc::new(Expr::Lam(Scope::new(
+                Embed(RcExpr::from(Expr::Lam(Scope::new(
                     FreeVar::user("x"),
-                    Rc::new(Expr::Var(Var::Free(FreeVar::user("x")))),
+                    RcExpr::from(Expr::Var(Var::Free(FreeVar::user("x")))),
                 )))),
             ),
         ])),
-        Rc::new(Expr::Var(Var::Free(FreeVar::user("test")))),
+        RcExpr::from(Expr::Var(Var::Free(FreeVar::user("test")))),
     )));
 
     assert_term_eq!(
         eval(&expr),
-        Rc::new(Expr::Var(Var::Free(FreeVar::user("x")))),
+        RcExpr::from(Expr::Var(Var::Free(FreeVar::user("x")))),
     );
 }
 

--- a/moniker/examples/lc_multi.rs
+++ b/moniker/examples/lc_multi.rs
@@ -13,27 +13,43 @@ pub enum Expr {
     /// Variables
     Var(Var<String>),
     /// Lambda expressions
-    Lam(Scope<Multi<FreeVar<String>>, Rc<Expr>>),
+    Lam(Scope<Multi<FreeVar<String>>, RcExpr>),
     /// Function application
-    App(Rc<Expr>, Vec<Rc<Expr>>),
+    App(RcExpr, Vec<RcExpr>),
 }
 
-// FIXME: auto-derive this somehow!
-fn substs(expr: &Rc<Expr>, mappings: &[(FreeVar<String>, Rc<Expr>)]) -> Rc<Expr> {
-    match **expr {
-        Expr::Var(Var::Free(ref n)) => match mappings.iter().find(|&(n2, _)| n == n2) {
-            Some((_, ref subst_expr)) => subst_expr.clone(),
-            None => expr.clone(),
-        },
-        Expr::Var(_) => expr.clone(),
-        Expr::Lam(ref scope) => Rc::new(Expr::Lam(Scope {
-            unsafe_pattern: scope.unsafe_pattern.clone(),
-            unsafe_body: substs(&scope.unsafe_body, mappings),
-        })),
-        Expr::App(ref fun, ref args) => Rc::new(Expr::App(
-            substs(fun, mappings),
-            args.iter().map(|arg| substs(arg, mappings)).collect(),
-        )),
+/// Reference counted expressions
+#[derive(Debug, Clone, BoundTerm)]
+pub struct RcExpr {
+    pub inner: Rc<Expr>,
+}
+
+impl From<Expr> for RcExpr {
+    fn from(src: Expr) -> RcExpr {
+        RcExpr {
+            inner: Rc::new(src),
+        }
+    }
+}
+
+impl RcExpr {
+    // FIXME: auto-derive this somehow!
+    fn substs(&self, mappings: &[(FreeVar<String>, RcExpr)]) -> RcExpr {
+        match *self.inner {
+            Expr::Var(Var::Free(ref n)) => match mappings.iter().find(|&(n2, _)| n == n2) {
+                Some((_, ref subst_expr)) => subst_expr.clone(),
+                None => self.clone(),
+            },
+            Expr::Var(_) => self.clone(),
+            Expr::Lam(ref scope) => RcExpr::from(Expr::Lam(Scope {
+                unsafe_pattern: scope.unsafe_pattern.clone(),
+                unsafe_body: scope.unsafe_body.substs(mappings),
+            })),
+            Expr::App(ref fun, ref args) => RcExpr::from(Expr::App(
+                fun.substs(mappings),
+                args.iter().map(|arg| arg.substs(mappings)).collect(),
+            )),
+        }
     }
 }
 
@@ -43,12 +59,12 @@ pub enum EvalError {
 }
 
 /// Evaluate an expression into its normal form
-pub fn eval(expr: &Rc<Expr>) -> Result<Rc<Expr>, EvalError> {
-    match **expr {
+pub fn eval(expr: &RcExpr) -> Result<RcExpr, EvalError> {
+    match *expr.inner {
         Expr::Var(Var::Free(_)) => Ok(expr.clone()),
         Expr::Var(Var::Bound(ref name, _)) => panic!("encountered a bound variable: {:?}", name),
         Expr::Lam(_) => Ok(expr.clone()),
-        Expr::App(ref fun, ref args) => match *eval(fun)? {
+        Expr::App(ref fun, ref args) => match *eval(fun)?.inner {
             Expr::Lam(ref scope) => {
                 let (Multi(params), body) = scope.clone().unbind();
 
@@ -58,13 +74,12 @@ pub fn eval(expr: &Rc<Expr>) -> Result<Rc<Expr>, EvalError> {
                         given: args.len(),
                     })
                 } else {
-                    eval(&substs(
-                        &body,
-                        &<_>::zip(
-                            params.into_iter(),
-                            args.iter().map(|arg| eval(arg).unwrap()),
-                        ).collect::<Vec<_>>(),
-                    ))
+                    let mappings = <_>::zip(
+                        params.into_iter(),
+                        args.iter().map(|arg| eval(arg).unwrap()),
+                    ).collect::<Vec<_>>();
+
+                    eval(&body.substs(&mappings))
                 }
             },
             _ => Ok(expr.clone()),
@@ -75,20 +90,20 @@ pub fn eval(expr: &Rc<Expr>) -> Result<Rc<Expr>, EvalError> {
 #[test]
 fn test_eval() {
     // expr = (fn(x, y) -> y)(a, b)
-    let expr = Rc::new(Expr::App(
-        Rc::new(Expr::Lam(Scope::new(
+    let expr = RcExpr::from(Expr::App(
+        RcExpr::from(Expr::Lam(Scope::new(
             Multi(vec![FreeVar::user("x"), FreeVar::user("y")]),
-            Rc::new(Expr::Var(Var::Free(FreeVar::user("y")))),
+            RcExpr::from(Expr::Var(Var::Free(FreeVar::user("y")))),
         ))),
         vec![
-            Rc::new(Expr::Var(Var::Free(FreeVar::user("a")))),
-            Rc::new(Expr::Var(Var::Free(FreeVar::user("b")))),
+            RcExpr::from(Expr::Var(Var::Free(FreeVar::user("a")))),
+            RcExpr::from(Expr::Var(Var::Free(FreeVar::user("b")))),
         ],
     ));
 
     assert_term_eq!(
         eval(&expr).unwrap(),
-        Rc::new(Expr::Var(Var::Free(FreeVar::user("b")))),
+        RcExpr::from(Expr::Var(Var::Free(FreeVar::user("b")))),
     );
 }
 

--- a/moniker/examples/stlc.rs
+++ b/moniker/examples/stlc.rs
@@ -22,7 +22,21 @@ pub enum Type {
     /// Strings
     String,
     /// Function types
-    Arrow(Rc<Type>, Rc<Type>),
+    Arrow(RcType, RcType),
+}
+
+/// Reference counted types
+#[derive(Debug, Clone, BoundTerm)]
+pub struct RcType {
+    pub inner: Rc<Type>,
+}
+
+impl From<Type> for RcType {
+    fn from(src: Type) -> RcType {
+        RcType {
+            inner: Rc::new(src),
+        }
+    }
 }
 
 /// Literal values
@@ -40,49 +54,65 @@ pub enum Literal {
 #[derive(Debug, Clone, BoundTerm)]
 pub enum Expr {
     /// Annotated expressions
-    Ann(Rc<Expr>, Rc<Type>),
+    Ann(RcExpr, RcType),
     /// Literals
     Literal(Literal),
     /// Variables
     Var(Var<String>),
     /// Lambda expressions, with an optional type annotation for the parameter
-    Lam(Scope<(FreeVar<String>, Embed<Option<Rc<Type>>>), Rc<Expr>>),
+    Lam(Scope<(FreeVar<String>, Embed<Option<RcType>>), RcExpr>),
     /// Function application
-    App(Rc<Expr>, Rc<Expr>),
+    App(RcExpr, RcExpr),
 }
 
-// FIXME: auto-derive this somehow!
-fn subst(expr: &Rc<Expr>, name: &FreeVar<String>, replacement: &Rc<Expr>) -> Rc<Expr> {
-    match **expr {
-        Expr::Ann(ref expr, ref ty) => {
-            Rc::new(Expr::Ann(subst(expr, name, replacement), ty.clone()))
-        },
-        Expr::Literal(_) => expr.clone(),
-        Expr::Var(Var::Free(ref n)) if name == n => replacement.clone(),
-        Expr::Var(_) => expr.clone(),
-        Expr::Lam(ref scope) => Rc::new(Expr::Lam(Scope {
-            unsafe_pattern: scope.unsafe_pattern.clone(),
-            unsafe_body: subst(&scope.unsafe_body, name, replacement),
-        })),
-        Expr::App(ref fun, ref arg) => Rc::new(Expr::App(
-            subst(fun, name, replacement),
-            subst(arg, name, replacement),
-        )),
+/// Reference counted expressions
+#[derive(Debug, Clone, BoundTerm)]
+pub struct RcExpr {
+    pub inner: Rc<Expr>,
+}
+
+impl From<Expr> for RcExpr {
+    fn from(src: Expr) -> RcExpr {
+        RcExpr {
+            inner: Rc::new(src),
+        }
+    }
+}
+
+impl RcExpr {
+    // FIXME: auto-derive this somehow!
+    fn subst(&self, name: &FreeVar<String>, replacement: &RcExpr) -> RcExpr {
+        match *self.inner {
+            Expr::Ann(ref expr, ref ty) => {
+                RcExpr::from(Expr::Ann(expr.subst(name, replacement), ty.clone()))
+            },
+            Expr::Literal(_) => self.clone(),
+            Expr::Var(Var::Free(ref n)) if name == n => replacement.clone(),
+            Expr::Var(_) => self.clone(),
+            Expr::Lam(ref scope) => RcExpr::from(Expr::Lam(Scope {
+                unsafe_pattern: scope.unsafe_pattern.clone(),
+                unsafe_body: scope.unsafe_body.subst(name, replacement),
+            })),
+            Expr::App(ref fun, ref arg) => RcExpr::from(Expr::App(
+                fun.subst(name, replacement),
+                arg.subst(name, replacement),
+            )),
+        }
     }
 }
 
 /// Evaluate an expression into its normal form
-pub fn eval(expr: &Rc<Expr>) -> Rc<Expr> {
-    match **expr {
+pub fn eval(expr: &RcExpr) -> RcExpr {
+    match *expr.inner {
         Expr::Ann(ref expr, _) => eval(expr),
         Expr::Literal(_) => expr.clone(),
         Expr::Var(Var::Free(_)) => expr.clone(),
         Expr::Var(Var::Bound(ref name, _)) => panic!("encountered a bound variable: {:?}", name),
         Expr::Lam(_) => expr.clone(),
-        Expr::App(ref fun, ref arg) => match *eval(fun) {
+        Expr::App(ref fun, ref arg) => match *eval(fun).inner {
             Expr::Lam(ref scope) => {
                 let ((name, _), body) = scope.clone().unbind();
-                eval(&subst(&body, &name, &eval(arg)))
+                eval(&body.subst(&name, &eval(arg)))
             },
             _ => expr.clone(),
         },
@@ -90,11 +120,11 @@ pub fn eval(expr: &Rc<Expr>) -> Rc<Expr> {
 }
 
 /// A context containing a series of type annotations
-type Context = HashMap<FreeVar<String>, Rc<Type>>;
+type Context = HashMap<FreeVar<String>, RcType>;
 
 /// Check that a (potentially ambiguous) expression conforms to a given type
-pub fn check(context: &Context, expr: &Rc<Expr>, expected_ty: &Rc<Type>) -> Result<(), String> {
-    match (&**expr, &**expected_ty) {
+pub fn check(context: &Context, expr: &RcExpr, expected_ty: &RcType) -> Result<(), String> {
+    match (&*expr.inner, &*expected_ty.inner) {
         (&Expr::Lam(ref scope), &Type::Arrow(ref param_ty, ref ret_ty)) => {
             if let ((name, Embed(None)), body) = scope.clone().unbind() {
                 check(&context.insert(name, param_ty.clone()), &body, ret_ty)?;
@@ -106,7 +136,7 @@ pub fn check(context: &Context, expr: &Rc<Expr>, expected_ty: &Rc<Type>) -> Resu
 
     let inferred_ty = infer(&context, expr)?;
 
-    if Type::term_eq(&inferred_ty, expected_ty) {
+    if RcType::term_eq(&inferred_ty, expected_ty) {
         Ok(())
     } else {
         Err(format!(
@@ -117,15 +147,15 @@ pub fn check(context: &Context, expr: &Rc<Expr>, expected_ty: &Rc<Type>) -> Resu
 }
 
 /// Synthesize the types of unambiguous expressions
-pub fn infer(context: &Context, expr: &Rc<Expr>) -> Result<Rc<Type>, String> {
-    match **expr {
+pub fn infer(context: &Context, expr: &RcExpr) -> Result<RcType, String> {
+    match *expr.inner {
         Expr::Ann(ref expr, ref ty) => {
             check(context, expr, ty)?;
             Ok(ty.clone())
         },
-        Expr::Literal(Literal::Int(_)) => Ok(Rc::new(Type::Int)),
-        Expr::Literal(Literal::Float(_)) => Ok(Rc::new(Type::Float)),
-        Expr::Literal(Literal::String(_)) => Ok(Rc::new(Type::String)),
+        Expr::Literal(Literal::Int(_)) => Ok(RcType::from(Type::Int)),
+        Expr::Literal(Literal::Float(_)) => Ok(RcType::from(Type::Float)),
+        Expr::Literal(Literal::String(_)) => Ok(RcType::from(Type::String)),
         Expr::Var(Var::Free(ref name)) => match context.get(name) {
             Some(term) => Ok((*term).clone()),
             None => Err(format!("`{:?}` not found", name)),
@@ -134,16 +164,16 @@ pub fn infer(context: &Context, expr: &Rc<Expr>) -> Result<Rc<Type>, String> {
         Expr::Lam(ref scope) => match scope.clone().unbind() {
             ((name, Embed(Some(ann))), body) => {
                 let body_ty = infer(&context.insert(name, ann.clone()), &body)?;
-                Ok(Rc::new(Type::Arrow(ann, body_ty)))
+                Ok(RcType::from(Type::Arrow(ann, body_ty)))
             },
             ((name, Embed(None)), _) => {
                 Err(format!("type annotation needed for argument `{:?}`", name))
             },
         },
-        Expr::App(ref fun, ref arg) => match *infer(context, fun)? {
+        Expr::App(ref fun, ref arg) => match *infer(context, fun)?.inner {
             Type::Arrow(ref param_ty, ref ret_ty) => {
                 let arg_ty = infer(context, arg)?;
-                if Type::term_eq(param_ty, &arg_ty) {
+                if RcType::term_eq(param_ty, &arg_ty) {
                     Ok(ret_ty.clone())
                 } else {
                     Err(format!(
@@ -160,14 +190,17 @@ pub fn infer(context: &Context, expr: &Rc<Expr>) -> Result<Rc<Type>, String> {
 #[test]
 fn test_infer() {
     // expr = (\x : Int -> x)
-    let expr = Rc::new(Expr::Lam(Scope::new(
-        (FreeVar::user("x"), Embed(Some(Rc::new(Type::Int)))),
-        Rc::new(Expr::Var(Var::Free(FreeVar::user("x")))),
+    let expr = RcExpr::from(Expr::Lam(Scope::new(
+        (FreeVar::user("x"), Embed(Some(RcType::from(Type::Int)))),
+        RcExpr::from(Expr::Var(Var::Free(FreeVar::user("x")))),
     )));
 
     assert_term_eq!(
         infer(&Context::new(), &expr).unwrap(),
-        Rc::new(Type::Arrow(Rc::new(Type::Int), Rc::new(Type::Int))),
+        RcType::from(Type::Arrow(
+            RcType::from(Type::Int),
+            RcType::from(Type::Int)
+        )),
     );
 }
 

--- a/moniker/examples/stlc_data.rs
+++ b/moniker/examples/stlc_data.rs
@@ -23,11 +23,25 @@ pub enum Type {
     /// Strings
     String,
     /// Function types
-    Arrow(Rc<Type>, Rc<Type>),
+    Arrow(RcType, RcType),
     /// Record types
-    Record(Vec<(String, Rc<Type>)>),
+    Record(Vec<(String, RcType)>),
     /// Variant types
-    Variant(Vec<(String, Rc<Type>)>),
+    Variant(Vec<(String, RcType)>),
+}
+
+/// Reference counted types
+#[derive(Debug, Clone, BoundTerm)]
+pub struct RcType {
+    pub inner: Rc<Type>,
+}
+
+impl From<Type> for RcType {
+    fn from(src: Type) -> RcType {
+        RcType {
+            inner: Rc::new(src),
+        }
+    }
 }
 
 /// Literal values
@@ -45,69 +59,85 @@ pub enum Literal {
 #[derive(Debug, Clone, BoundTerm)]
 pub enum Expr {
     /// Annotated expressions
-    Ann(Rc<Expr>, Rc<Type>),
+    Ann(RcExpr, RcType),
     /// Literals
     Literal(Literal),
     /// Variables
     Var(Var<String>),
     /// Lambda expressions, with an optional type annotation for the parameter
-    Lam(Scope<(FreeVar<String>, Embed<Option<Rc<Type>>>), Rc<Expr>>),
+    Lam(Scope<(FreeVar<String>, Embed<Option<RcType>>), RcExpr>),
     /// Function application
-    App(Rc<Expr>, Rc<Expr>),
+    App(RcExpr, RcExpr),
     /// Record values
-    Record(Vec<(String, Rc<Expr>)>),
+    Record(Vec<(String, RcExpr)>),
     /// Field projection on records
-    Proj(Rc<Expr>, String),
+    Proj(RcExpr, String),
     /// Variant introduction
-    Tag(String, Rc<Expr>),
+    Tag(String, RcExpr),
 }
 
-// FIXME: auto-derive this somehow!
-fn subst(expr: &Rc<Expr>, name: &FreeVar<String>, replacement: &Rc<Expr>) -> Rc<Expr> {
-    match **expr {
-        Expr::Ann(ref expr, ref ty) => {
-            Rc::new(Expr::Ann(subst(expr, name, replacement), ty.clone()))
-        },
-        Expr::Literal(_) => expr.clone(),
-        Expr::Var(Var::Free(ref n)) if name == n => replacement.clone(),
-        Expr::Var(_) => expr.clone(),
-        Expr::Lam(ref scope) => Rc::new(Expr::Lam(Scope {
-            unsafe_pattern: scope.unsafe_pattern.clone(),
-            unsafe_body: subst(&scope.unsafe_body, name, replacement),
-        })),
-        Expr::App(ref fun, ref arg) => Rc::new(Expr::App(
-            subst(fun, name, replacement),
-            subst(arg, name, replacement),
-        )),
-        Expr::Record(ref fields) => {
-            let fields = fields
-                .iter()
-                .map(|&(ref label, ref elem)| (label.clone(), subst(elem, name, replacement)))
-                .collect();
+/// Reference counted expressions
+#[derive(Debug, Clone, BoundTerm)]
+pub struct RcExpr {
+    pub inner: Rc<Expr>,
+}
 
-            Rc::new(Expr::Record(fields))
-        },
-        Expr::Proj(ref expr, ref label) => {
-            Rc::new(Expr::Proj(subst(expr, name, replacement), label.clone()))
-        },
-        Expr::Tag(ref label, ref expr) => {
-            Rc::new(Expr::Tag(label.clone(), subst(expr, name, replacement)))
-        },
+impl From<Expr> for RcExpr {
+    fn from(src: Expr) -> RcExpr {
+        RcExpr {
+            inner: Rc::new(src),
+        }
+    }
+}
+
+impl RcExpr {
+    // FIXME: auto-derive this somehow!
+    fn subst(&self, name: &FreeVar<String>, replacement: &RcExpr) -> RcExpr {
+        match *self.inner {
+            Expr::Ann(ref expr, ref ty) => {
+                RcExpr::from(Expr::Ann(expr.subst(name, replacement), ty.clone()))
+            },
+            Expr::Literal(_) => self.clone(),
+            Expr::Var(Var::Free(ref n)) if name == n => replacement.clone(),
+            Expr::Var(_) => self.clone(),
+            Expr::Lam(ref scope) => RcExpr::from(Expr::Lam(Scope {
+                unsafe_pattern: scope.unsafe_pattern.clone(),
+                unsafe_body: scope.unsafe_body.subst(name, replacement),
+            })),
+            Expr::App(ref fun, ref arg) => RcExpr::from(Expr::App(
+                fun.subst(name, replacement),
+                arg.subst(name, replacement),
+            )),
+            Expr::Record(ref fields) => {
+                let fields = fields
+                    .iter()
+                    .map(|&(ref label, ref elem)| (label.clone(), elem.subst(name, replacement)))
+                    .collect();
+
+                RcExpr::from(Expr::Record(fields))
+            },
+            Expr::Proj(ref expr, ref label) => {
+                RcExpr::from(Expr::Proj(expr.subst(name, replacement), label.clone()))
+            },
+            Expr::Tag(ref label, ref expr) => {
+                RcExpr::from(Expr::Tag(label.clone(), expr.subst(name, replacement)))
+            },
+        }
     }
 }
 
 /// Evaluate an expression into its normal form
-pub fn eval(expr: &Rc<Expr>) -> Rc<Expr> {
-    match **expr {
+pub fn eval(expr: &RcExpr) -> RcExpr {
+    match *expr.inner {
         Expr::Ann(ref expr, _) => eval(expr),
         Expr::Literal(_) => expr.clone(),
         Expr::Var(Var::Free(_)) => expr.clone(),
         Expr::Var(Var::Bound(ref name, _)) => panic!("encountered a bound variable: {:?}", name),
         Expr::Lam(_) => expr.clone(),
-        Expr::App(ref fun, ref arg) => match *eval(fun) {
+        Expr::App(ref fun, ref arg) => match *eval(fun).inner {
             Expr::Lam(ref scope) => {
                 let ((name, _), body) = scope.clone().unbind();
-                eval(&subst(&body, &name, &eval(arg)))
+                eval(&body.subst(&name, &eval(arg)))
             },
             _ => expr.clone(),
         },
@@ -117,12 +147,12 @@ pub fn eval(expr: &Rc<Expr>) -> Rc<Expr> {
                 .map(|&(ref label, ref elem)| (label.clone(), eval(elem)))
                 .collect();
 
-            Rc::new(Expr::Record(fields))
+            RcExpr::from(Expr::Record(fields))
         },
         Expr::Proj(ref expr, ref label) => {
             let expr = eval(expr);
 
-            if let Expr::Record(ref fields) = *expr {
+            if let Expr::Record(ref fields) = *expr.inner {
                 if let Some(&(_, ref e)) = fields.iter().find(|&(ref l, _)| l == label) {
                     return e.clone();
                 }
@@ -130,16 +160,16 @@ pub fn eval(expr: &Rc<Expr>) -> Rc<Expr> {
 
             expr
         },
-        Expr::Tag(ref label, ref expr) => Rc::new(Expr::Tag(label.clone(), eval(expr))),
+        Expr::Tag(ref label, ref expr) => RcExpr::from(Expr::Tag(label.clone(), eval(expr))),
     }
 }
 
 /// A context containing a series of type annotations
-type Context = HashMap<FreeVar<String>, Rc<Type>>;
+type Context = HashMap<FreeVar<String>, RcType>;
 
 /// Check that a (potentially ambiguous) expression conforms to a given ype
-pub fn check(context: &Context, expr: &Rc<Expr>, expected_ty: &Rc<Type>) -> Result<(), String> {
-    match (&**expr, &**expected_ty) {
+pub fn check(context: &Context, expr: &RcExpr, expected_ty: &RcType) -> Result<(), String> {
+    match (&*expr.inner, &*expected_ty.inner) {
         (&Expr::Lam(ref scope), &Type::Arrow(ref param_ty, ref ret_ty)) => {
             if let ((name, Embed(None)), body) = scope.clone().unbind() {
                 check(&context.insert(name, param_ty.clone()), &body, ret_ty)?;
@@ -160,7 +190,7 @@ pub fn check(context: &Context, expr: &Rc<Expr>, expected_ty: &Rc<Type>) -> Resu
 
     let inferred_ty = infer(&context, expr)?;
 
-    if Type::term_eq(&inferred_ty, expected_ty) {
+    if RcType::term_eq(&inferred_ty, expected_ty) {
         Ok(())
     } else {
         Err(format!(
@@ -171,15 +201,15 @@ pub fn check(context: &Context, expr: &Rc<Expr>, expected_ty: &Rc<Type>) -> Resu
 }
 
 /// Synthesize the types of unambiguous expressions
-pub fn infer(context: &Context, expr: &Rc<Expr>) -> Result<Rc<Type>, String> {
-    match **expr {
+pub fn infer(context: &Context, expr: &RcExpr) -> Result<RcType, String> {
+    match *expr.inner {
         Expr::Ann(ref expr, ref ty) => {
             check(context, expr, ty)?;
             Ok(ty.clone())
         },
-        Expr::Literal(Literal::Int(_)) => Ok(Rc::new(Type::Int)),
-        Expr::Literal(Literal::Float(_)) => Ok(Rc::new(Type::Float)),
-        Expr::Literal(Literal::String(_)) => Ok(Rc::new(Type::String)),
+        Expr::Literal(Literal::Int(_)) => Ok(RcType::from(Type::Int)),
+        Expr::Literal(Literal::Float(_)) => Ok(RcType::from(Type::Float)),
+        Expr::Literal(Literal::String(_)) => Ok(RcType::from(Type::String)),
         Expr::Var(Var::Free(ref name)) => match context.get(name) {
             Some(term) => Ok((*term).clone()),
             None => Err(format!("`{:?}` not found", name)),
@@ -188,16 +218,16 @@ pub fn infer(context: &Context, expr: &Rc<Expr>) -> Result<Rc<Type>, String> {
         Expr::Lam(ref scope) => match scope.clone().unbind() {
             ((name, Embed(Some(ann))), body) => {
                 let body_ty = infer(&context.insert(name, ann.clone()), &body)?;
-                Ok(Rc::new(Type::Arrow(ann, body_ty)))
+                Ok(RcType::from(Type::Arrow(ann, body_ty)))
             },
             ((name, Embed(None)), _) => {
                 Err(format!("type annotation needed for argument `{:?}`", name))
             },
         },
-        Expr::App(ref fun, ref arg) => match *infer(context, fun)? {
+        Expr::App(ref fun, ref arg) => match *infer(context, fun)?.inner {
             Type::Arrow(ref param_ty, ref ret_ty) => {
                 let arg_ty = infer(context, arg)?;
-                if Type::term_eq(param_ty, &arg_ty) {
+                if RcType::term_eq(param_ty, &arg_ty) {
                     Ok(ret_ty.clone())
                 } else {
                     Err(format!(
@@ -208,13 +238,13 @@ pub fn infer(context: &Context, expr: &Rc<Expr>) -> Result<Rc<Type>, String> {
             },
             _ => Err(format!("`{:?}` is not a function", fun)),
         },
-        Expr::Record(ref elems) => Ok(Rc::new(Type::Record(
+        Expr::Record(ref elems) => Ok(RcType::from(Type::Record(
             elems
                 .iter()
                 .map(|&(ref label, ref expr)| Ok((label.clone(), infer(context, expr)?)))
                 .collect::<Result<_, String>>()?,
         ))),
-        Expr::Proj(ref expr, ref label) => match *infer(context, expr)? {
+        Expr::Proj(ref expr, ref label) => match *infer(context, expr)?.inner {
             Type::Record(ref elems) => match elems.iter().find(|&(l, _)| l == label) {
                 Some(&(_, ref ty)) => Ok(ty.clone()),
                 None => Err(format!("field `{}` not found in type", label)),
@@ -228,14 +258,17 @@ pub fn infer(context: &Context, expr: &Rc<Expr>) -> Result<Rc<Type>, String> {
 #[test]
 fn test_infer() {
     // expr = (\x : Int -> x)
-    let expr = Rc::new(Expr::Lam(Scope::new(
-        (FreeVar::user("x"), Embed(Some(Rc::new(Type::Int)))),
-        Rc::new(Expr::Var(Var::Free(FreeVar::user("x")))),
+    let expr = RcExpr::from(Expr::Lam(Scope::new(
+        (FreeVar::user("x"), Embed(Some(RcType::from(Type::Int)))),
+        RcExpr::from(Expr::Var(Var::Free(FreeVar::user("x")))),
     )));
 
     assert_term_eq!(
         infer(&Context::new(), &expr).unwrap(),
-        Rc::new(Type::Arrow(Rc::new(Type::Int), Rc::new(Type::Int))),
+        RcType::from(Type::Arrow(
+            RcType::from(Type::Int),
+            RcType::from(Type::Int)
+        )),
     );
 }
 


### PR DESCRIPTION
This should make it easier to derive the `Subst` trait in the future! (see issue #11)