### PR TITLE
Workaround silent ignores of cargo features

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,19 +6,23 @@ rust:
   - beta
   - nightly
 env:
-  - CARGO_FEATURES=""
-  - CARGO_FEATURES="codespan"
-  - CARGO_FEATURES="default"
-  - CARGO_FEATURES="default codespan"
+  - MONIKER_CARGO_FEATURES=""
+  - MONIKER_CARGO_FEATURES="codespan"
+  - MONIKER_CARGO_FEATURES="default"
+  - MONIKER_CARGO_FEATURES="default codespan"
 matrix:
   allow_failures:
     - rust: nightly
 script:
-  - cargo build --no-default-features --features "$CARGO_FEATURES" --verbose
-  - cargo test --no-default-features --features "$CARGO_FEATURES" --verbose
-  - bash -c 'if [[ $CARGO_FEATURES = *"default"* ]]; then
-      cargo test --no-default-features --features "$CARGO_FEATURES" --examples --verbose;
-    fi'
+  # moniker-derive
+  - cargo build --manifest-path=moniker-derive/Cargo.toml --verbose
+  - cargo test --manifest-path=moniker-derive/Cargo.toml --verbose
+  # moniker
+  - cargo build --manifest-path=moniker/Cargo.toml --no-default-features --features="$MONIKER_CARGO_FEATURES" --verbose
+  - cargo test --manifest-path=moniker/Cargo.toml --no-default-features --features="$MONIKER_CARGO_FEATURES" --verbose
+  # moniker examples
+  - cargo build --manifest-path=moniker/Cargo.toml --no-default-features --features="$MONIKER_CARGO_FEATURES" --verbose --examples
+  - cargo test --manifest-path=moniker/Cargo.toml --no-default-features --features="$MONIKER_CARGO_FEATURES" --verbose --examples
 notifications:
   webhooks:
     urls:

--- a/moniker/Cargo.toml
+++ b/moniker/Cargo.toml
@@ -28,3 +28,31 @@ codespan = { version = "0.1.2", optional = true }
 
 [dev-dependencies]
 im = "10.2"
+
+[[example]]
+name = "lc"
+required-features = ["moniker-derive"]
+
+[[example]]
+name = "lc_let"
+required-features = ["moniker-derive"]
+
+[[example]]
+name = "lc_letrec"
+required-features = ["moniker-derive"]
+
+[[example]]
+name = "lc_multi"
+required-features = ["moniker-derive"]
+
+[[example]]
+name = "stlc"
+required-features = ["moniker-derive"]
+
+[[example]]
+name = "stlc_data"
+required-features = ["moniker-derive"]
+
+[[example]]
+name = "stlc_data_isorec"
+required-features = ["moniker-derive"]

--- a/moniker/src/bound.rs
+++ b/moniker/src/bound.rs
@@ -193,7 +193,7 @@ impl_bound_term_partial_eq!(f64);
 macro_rules! impl_bound_term_ignore {
     ($T:ty) => {
         impl<Ident> BoundTerm<Ident> for $T {
-            fn term_eq(&self, other: &$T) -> bool {
+            fn term_eq(&self, _: &$T) -> bool {
                 true
             }
 
@@ -227,7 +227,7 @@ impl_bound_term_ignore!(LineOffset);
 
 #[cfg(feature = "codespan")]
 impl<Ident, T> BoundTerm<Ident> for Span<T> {
-    fn term_eq(&self, other: &Span<T>) -> bool {
+    fn term_eq(&self, _: &Span<T>) -> bool {
         true
     }
 
@@ -645,7 +645,7 @@ impl_bound_pattern_partial_eq!(f64);
 macro_rules! impl_bound_pattern_ignore {
     ($T:ty) => {
         impl<Ident> BoundPattern<Ident> for $T {
-            fn pattern_eq(&self, other: &$T) -> bool {
+            fn pattern_eq(&self, _: &$T) -> bool {
                 true
             }
 
@@ -688,8 +688,8 @@ impl_bound_pattern_ignore!(LineNumber);
 impl_bound_pattern_ignore!(LineOffset);
 
 #[cfg(feature = "codespan")]
-impl<Ident, T> BoundTerm<Ident> for Span<T> {
-    fn pattern_eq(&self, other: &Span<T>) -> bool {
+impl<Ident, T> BoundPattern<Ident> for Span<T> {
+    fn pattern_eq(&self, _: &Span<T>) -> bool {
         true
     }
 


### PR DESCRIPTION
This tripped me up and caused me a couple of hours of confusion. Cargo does not seem to pass on features to subcrates in a virtual workspace, nor does it respond to something you’d expect, like `cargo test -features=“moniker/codespan”`. This meant that I actually comitted buggy code to the repository!

I’m working around this for now using `--manifest-path` method - it’s pretty gross though. There is an issue at rust-lang/cargo#4942 recording other people’s experiences with this behaviour.