### PR TITLE
Fix patterns and add example of pattern matching

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ in Rust.
 #[macro_use]
 extern crate moniker;
 
-use moniker::{Embed, FreeVar, Scope, Var};
+use moniker::{Embed, PVar, Scope, TVar};
 use std::rc::Rc;
 
 #[derive(Debug, Clone, BoundTerm)]
@@ -30,8 +30,8 @@ pub enum Type {
 
 #[derive(Debug, Clone, BoundTerm)]
 pub enum Expr {
-    Var(Var<String>),
-    Lam(Scope<(FreeVar<String>, Embed<Rc<Type>>), Rc<Expr>>),
+    Var(TVar<String>),
+    Lam(Scope<(PVar<String>, Embed<Rc<Type>>), Rc<Expr>>),
     App(Rc<Expr>, Rc<Expr>),
 }
 ```

--- a/moniker-derive/src/lib.rs
+++ b/moniker-derive/src/lib.rs
@@ -8,9 +8,9 @@ extern crate proc_macro2;
 
 use synstructure::{BindStyle, Structure};
 
-decl_derive!([BoundTerm] => term_derive);
+decl_derive!([BoundTerm] => bound_term_derive);
 
-fn term_derive(mut s: Structure) -> proc_macro2::TokenStream {
+fn bound_term_derive(mut s: Structure) -> proc_macro2::TokenStream {
     s.bind_with(|_| BindStyle::Ref);
     let term_eq_body = {
         let body = s.variants().iter().fold(quote!(), |acc, v| {
@@ -93,12 +93,141 @@ fn term_derive(mut s: Structure) -> proc_macro2::TokenStream {
                 match *self { #open_term_body }
             }
 
-            fn visit_vars(&self, __on_var: &mut impl FnMut(&moniker::Var<String>)) {
+            fn visit_vars(&self, __on_var: &mut impl FnMut(&moniker::TVar<String>)) {
                 match *self { #visit_vars_body }
             }
 
-            fn visit_mut_vars(&mut self, __on_var: &mut impl FnMut(&mut moniker::Var<String>)) {
+            fn visit_mut_vars(&mut self, __on_var: &mut impl FnMut(&mut moniker::TVar<String>)) {
                 match *self { #visit_mut_vars_body }
+            }
+        }
+    })
+}
+
+decl_derive!([BoundPattern] => bound_pattern_derive);
+
+fn bound_pattern_derive(mut s: Structure) -> proc_macro2::TokenStream {
+    s.bind_with(|_| BindStyle::Ref);
+    let pattern_eq_body = {
+        let body = s.variants().iter().fold(quote!(), |acc, v| {
+            // Create two sets of bindings, one for the lhs, and another for the rhs
+            let mut lhs = v.clone();
+            let mut rhs = v.clone();
+            lhs.binding_name(|_, i| {
+                syn::Ident::new(
+                    &format!("__binding_lhs_{}", i),
+                    proc_macro2::Span::call_site(),
+                )
+            });
+            rhs.binding_name(|_, i| {
+                syn::Ident::new(
+                    &format!("__binding_rhs_{}", i),
+                    proc_macro2::Span::call_site(),
+                )
+            });
+
+            let lhs_pat = lhs.pat();
+            let rhs_pat = rhs.pat();
+
+            // build up the alpha-equality expression for this variant
+            let arm_body = <_>::zip(lhs.bindings().iter(), rhs.bindings()).fold(
+                quote!(true),
+                |acc, (lhs, rhs)| {
+                    quote! { #acc && moniker::BoundPattern::<String>::pattern_eq(#lhs, #rhs) }
+                },
+            );
+
+            quote! { #acc (&#lhs_pat, &#rhs_pat) => #arm_body, }
+        });
+
+        // Avoid the 'unreachable match' warning for types with zero or one variants
+        match s.variants().len() {
+            0 | 1 => body,
+            _ => quote! { #body (_, _) => false },
+        }
+    };
+
+    s.bind_with(|_| BindStyle::RefMut);
+    let freshen_body = s.each(|bi| {
+        quote!{ moniker::BoundPattern::<String>::freshen(#bi, __permutations); }
+    });
+    let swaps_body = s.each(|bi| {
+        quote!{ moniker::BoundPattern::<String>::swaps(#bi, __permutations); }
+    });
+
+    s.bind_with(|_| BindStyle::RefMut);
+    let close_pattern_body = s.each(|bi| {
+        quote!{ moniker::BoundPattern::<String>::close_pattern(#bi, __state, __pattern); }
+    });
+    let open_pattern_body = s.each(|bi| {
+        quote!{ moniker::BoundPattern::<String>::open_pattern(#bi, __state, __pattern); }
+    });
+
+    s.bind_with(|_| BindStyle::Ref);
+    let find_pvar_index_body = s.each(|bi| {
+        quote! {
+            match #bi.find_pvar_index(__free_var) {
+                Ok(__pvar_index) => return Ok(__pvar_index + __skipped),
+                Err(__next_skipped) => __skipped += __next_skipped,
+            };
+        }
+    });
+    let find_pvar_at_offset_body = s.each(|bi| {
+        quote! {
+            match #bi.find_pvar_at_offset(__offset) {
+                Ok(__pvar) => return Ok(__pvar),
+                Err(__next_offset) => __offset = __next_offset,
+            };
+        }
+    });
+
+    s.gen_impl(quote! {
+        extern crate moniker;
+
+        gen impl moniker::BoundPattern<String> for @Self {
+            fn pattern_eq(&self, other: &Self) -> bool {
+                match (self, other) { #pattern_eq_body }
+            }
+
+            fn freshen(&mut self, __permutations: &mut moniker::Permutations<String>) {
+                match *self { #freshen_body }
+            }
+
+            fn swaps(&mut self, __permutations: &moniker::Permutations<String>) {
+                match *self { #swaps_body }
+            }
+
+            fn close_pattern(
+                &mut self,
+                __state: moniker::ScopeState,
+                __pattern: &impl moniker::BoundPattern<String>,
+            ) {
+                match *self { #close_pattern_body }
+            }
+
+            fn open_pattern(
+                &mut self,
+                __state: moniker::ScopeState,
+                __pattern: &impl moniker::BoundPattern<String>,
+            ) {
+                match *self { #open_pattern_body }
+            }
+
+            fn find_pvar_index(
+                &self,
+                __free_var: &moniker::FreeVar<String>,
+            ) -> Result<moniker::PVarIndex, moniker::PVarOffset> {
+                let mut __skipped = moniker::PVarOffset(0);
+                match *self { #find_pvar_index_body }
+                Err(__skipped)
+            }
+
+            fn find_pvar_at_offset(
+                &self,
+                mut __offset: moniker::PVarOffset,
+            ) -> Result<moniker::PVar<String>, moniker::PVarOffset> {
+                match *self { #find_pvar_at_offset_body }
+                Err(__offset)
             }
         }
     })

--- a/moniker/examples/stlc_data.rs
+++ b/moniker/examples/stlc_data.rs
@@ -1,16 +1,20 @@
 //! An example of using the `moniker` library to implement the simply typed
-//! lambda calculus, with the ability to construct compound datatypes like
-//! records and variants
+//! lambda calculus with records, variants, literals, and pattern matching.
 //!
 //! We use [bidirectional type checking](http://www.davidchristiansen.dk/tutorials/bidirectional.pdf)
 //! to get some level of type inference.
+//!
+//! To implement pattern matching we referred to:
+//!
+//! - [The Locally Nameless Representation (Section 7.3)](https://www.chargueraud.org/research/2009/ln/main.pdf)
+//! - [Towards a practical programming language based on dependent type theory (Chapter 2)]()
 
 extern crate im;
 #[macro_use]
 extern crate moniker;
 
 use im::HashMap;
-use moniker::{BoundTerm, Embed, FreeVar, Scope, Var};
+use moniker::{BoundTerm, Embed, FreeVar, PVar, Scope, TVar};
 use std::rc::Rc;
 
 /// Types
@@ -45,7 +49,7 @@ impl From<Type> for RcType {
 }
 
 /// Literal values
-#[derive(Debug, Clone, BoundTerm)]
+#[derive(Debug, Clone, PartialEq, BoundTerm, BoundPattern)]
 pub enum Literal {
     /// Integer literals
     Int(i32),
@@ -53,6 +57,29 @@ pub enum Literal {
     Float(f32),
     /// String literals
     String(String),
+}
+
+#[derive(Debug, Clone, BoundPattern)]
+pub enum Pattern {
+    Ann(RcPattern, Embed<RcType>),
+    Literal(Literal),
+    Var(PVar<String>),
+    Record(Vec<(String, RcPattern)>),
+    Tag(String, RcPattern),
+}
+
+/// Reference counted patterns
+#[derive(Debug, Clone, BoundPattern)]
+pub struct RcPattern {
+    pub inner: Rc<Pattern>,
+}
+
+impl From<Pattern> for RcPattern {
+    fn from(src: Pattern) -> RcPattern {
+        RcPattern {
+            inner: Rc::new(src),
+        }
+    }
 }
 
 /// Expressions
@@ -63,9 +90,9 @@ pub enum Expr {
     /// Literals
     Literal(Literal),
     /// Variables
-    Var(Var<String>),
-    /// Lambda expressions, with an optional type annotation for the parameter
-    Lam(Scope<(FreeVar<String>, Embed<Option<RcType>>), RcExpr>),
+    Var(TVar<String>),
+    /// Lambda expressions
+    Lam(Scope<RcPattern, RcExpr>),
     /// Function application
     App(RcExpr, RcExpr),
     /// Record values
@@ -74,6 +101,8 @@ pub enum Expr {
     Proj(RcExpr, String),
     /// Variant introduction
     Tag(String, RcExpr),
+    /// Case expressions
+    Case(RcExpr, Vec<Scope<RcPattern, RcExpr>>),
 }
 
 /// Reference counted expressions
@@ -92,36 +121,50 @@ impl From<Expr> for RcExpr {
 
 impl RcExpr {
     // FIXME: auto-derive this somehow!
-    fn subst(&self, name: &FreeVar<String>, replacement: &RcExpr) -> RcExpr {
+    fn substs<N>(&self, mappings: &[(N, RcExpr)]) -> RcExpr
+    where
+        TVar<String>: PartialEq<N>,
+    {
         match *self.inner {
             Expr::Ann(ref expr, ref ty) => {
-                RcExpr::from(Expr::Ann(expr.subst(name, replacement), ty.clone()))
+                RcExpr::from(Expr::Ann(expr.substs(mappings), ty.clone()))
+            },
+            Expr::Var(ref n) => match mappings.iter().find(|&(n2, _)| n == n2) {
+                Some((_, ref subst_expr)) => subst_expr.clone(),
+                None => self.clone(),
             },
             Expr::Literal(_) => self.clone(),
-            Expr::Var(Var::Free(ref n)) if name == n => replacement.clone(),
-            Expr::Var(_) => self.clone(),
             Expr::Lam(ref scope) => RcExpr::from(Expr::Lam(Scope {
                 unsafe_pattern: scope.unsafe_pattern.clone(),
-                unsafe_body: scope.unsafe_body.subst(name, replacement),
+                unsafe_body: scope.unsafe_body.substs(mappings),
             })),
-            Expr::App(ref fun, ref arg) => RcExpr::from(Expr::App(
-                fun.subst(name, replacement),
-                arg.subst(name, replacement),
-            )),
+            Expr::App(ref fun, ref arg) => {
+                RcExpr::from(Expr::App(fun.substs(mappings), arg.substs(mappings)))
+            },
             Expr::Record(ref fields) => {
                 let fields = fields
                     .iter()
-                    .map(|&(ref label, ref elem)| (label.clone(), elem.subst(name, replacement)))
+                    .map(|&(ref label, ref elem)| (label.clone(), elem.substs(mappings)))
                     .collect();
 
                 RcExpr::from(Expr::Record(fields))
             },
             Expr::Proj(ref expr, ref label) => {
-                RcExpr::from(Expr::Proj(expr.subst(name, replacement), label.clone()))
+                RcExpr::from(Expr::Proj(expr.substs(mappings), label.clone()))
             },
             Expr::Tag(ref label, ref expr) => {
-                RcExpr::from(Expr::Tag(label.clone(), expr.subst(name, replacement)))
+                RcExpr::from(Expr::Tag(label.clone(), expr.substs(mappings)))
             },
+            Expr::Case(ref expr, ref clauses) => RcExpr::from(Expr::Case(
+                expr.substs(mappings),
+                clauses
+                    .iter()
+                    .map(|scope| Scope {
+                        unsafe_pattern: scope.unsafe_pattern.clone(), // subst?
+                        unsafe_body: scope.unsafe_body.substs(mappings),
+                    })
+                    .collect(),
+            )),
         }
     }
 }
@@ -133,8 +176,11 @@ pub fn eval(expr: &RcExpr) -> RcExpr {
         Expr::Literal(_) | Expr::Var(_) | Expr::Lam(_) => expr.clone(),
         Expr::App(ref fun, ref arg) => match *eval(fun).inner {
             Expr::Lam(ref scope) => {
-                let ((name, _), body) = scope.clone().unbind();
-                eval(&body.subst(&name, &eval(arg)))
+                let (pattern, body) = scope.clone().unbind();
+                match match_expr(&pattern, &eval(arg)) {
+                    None => expr.clone(), // stuck
+                    Some(mappings) => eval(&body.substs(&mappings)),
+                }
             },
             _ => expr.clone(),
         },
@@ -158,6 +204,55 @@ pub fn eval(expr: &RcExpr) -> RcExpr {
             expr
         },
         Expr::Tag(ref label, ref expr) => RcExpr::from(Expr::Tag(label.clone(), eval(expr))),
+        Expr::Case(ref arg, ref clauses) => {
+            for clause in clauses {
+                let (pattern, body) = clause.clone().unbind();
+                match match_expr(&pattern, &eval(arg)) {
+                    None => {}, // stuck
+                    Some(mappings) => return eval(&body.substs(&mappings)),
+                }
+            }
+            expr.clone() // stuck
+        },
+    }
+}
+
+/// If the pattern matches the expression, this function returns the
+/// substitutions needed to apply the pattern to some body expression
+///
+/// We assume that the given expression has been evaluated first!
+pub fn match_expr(pattern: &RcPattern, expr: &RcExpr) -> Option<Vec<(FreeVar<String>, RcExpr)>> {
+    match (&*pattern.inner, &*expr.inner) {
+        (&Pattern::Ann(ref pattern, _), _) => match_expr(pattern, expr),
+        (&Pattern::Literal(ref pattern_lit), &Expr::Literal(ref expr_lit))
+            if pattern_lit == expr_lit =>
+        {
+            Some(vec![])
+        },
+        (&Pattern::Var(PVar::Free(ref free_var)), _) => {
+            Some(vec![(free_var.clone(), expr.clone())])
+        },
+        (&Pattern::Var(PVar::Bound(_, _)), _) => None, // oopsie
+        (&Pattern::Record(ref pattern_fields), &Expr::Record(ref expr_fields))
+            if pattern_fields.len() == expr_fields.len() =>
+        {
+            // FIXME: allow out-of-order fields in records
+            let mut mappings = Vec::new();
+            for (pattern_field, expr_field) in <_>::zip(pattern_fields.iter(), expr_fields.iter()) {
+                if pattern_field.0 != expr_field.0 {
+                    return None;
+                } else {
+                    mappings.extend(match_expr(&pattern_field.1, &expr_field.1)?);
+                }
+            }
+            Some(mappings)
+        }
+        (&Pattern::Tag(ref pattern_label, ref pattern), &Expr::Tag(ref expr_label, ref expr))
+            if pattern_label == expr_label =>
+        {
+            match_expr(pattern, expr)
+        },
+        (_, _) => None,
     }
 }
 
@@ -165,13 +260,12 @@ pub fn eval(expr: &RcExpr) -> RcExpr {
 type Context = HashMap<FreeVar<String>, RcType>;
 
 /// Check that a (potentially ambiguous) expression conforms to a given ype
-pub fn check(context: &Context, expr: &RcExpr, expected_ty: &RcType) -> Result<(), String> {
+pub fn check_expr(context: &Context, expr: &RcExpr, expected_ty: &RcType) -> Result<(), String> {
     match (&*expr.inner, &*expected_ty.inner) {
         (&Expr::Lam(ref scope), &Type::Arrow(ref param_ty, ref ret_ty)) => {
-            if let ((name, Embed(None)), body) = scope.clone().unbind() {
-                check(&context.insert(name, param_ty.clone()), &body, ret_ty)?;
-                return Ok(());
-            }
+            let (pattern, body) = scope.clone().unbind();
+            let bindings = check_pattern(context, &pattern, param_ty)?;
+            return check_expr(&(context + &bindings), &body, ret_ty);
         },
         (&Expr::Tag(ref label, ref expr), &Type::Variant(ref variants)) => {
             return match variants.iter().find(|&(l, _)| l == label) {
@@ -179,14 +273,24 @@ pub fn check(context: &Context, expr: &RcExpr, expected_ty: &RcType) -> Result<(
                     "variant type did not contain the label `{}`",
                     label
                 )),
-                Some(&(_, ref ty)) => check(context, expr, ty),
+                Some(&(_, ref ty)) => check_expr(context, expr, ty),
             };
+        },
+        (&Expr::Case(ref expr, ref clauses), _) => {
+            let expr_ty = infer_expr(context, expr)?;
+            for clause in clauses {
+                let (pattern, body) = clause.clone().unbind();
+                let bindings = check_pattern(context, &pattern, &expr_ty)?;
+                check_expr(&(context + &bindings), &body, expected_ty)?;
+            }
+            return Ok(());
         },
         (_, _) => {},
     }
 
-    let inferred_ty = infer(&context, expr)?;
+    let inferred_ty = infer_expr(&context, expr)?;
 
+    // FIXME: allow out-of-order fields in records
     if RcType::term_eq(&inferred_ty, expected_ty) {
         Ok(())
     } else {
@@ -198,32 +302,33 @@ pub fn check(context: &Context, expr: &RcExpr, expected_ty: &RcType) -> Result<(
 }
 
 /// Synthesize the types of unambiguous expressions
-pub fn infer(context: &Context, expr: &RcExpr) -> Result<RcType, String> {
+pub fn infer_expr(context: &Context, expr: &RcExpr) -> Result<RcType, String> {
     match *expr.inner {
         Expr::Ann(ref expr, ref ty) => {
-            check(context, expr, ty)?;
+            check_expr(context, expr, ty)?;
             Ok(ty.clone())
         },
         Expr::Literal(Literal::Int(_)) => Ok(RcType::from(Type::Int)),
         Expr::Literal(Literal::Float(_)) => Ok(RcType::from(Type::Float)),
         Expr::Literal(Literal::String(_)) => Ok(RcType::from(Type::String)),
-        Expr::Var(Var::Free(ref name)) => match context.get(name) {
+        Expr::Var(ref var) => match context.get(
+            // FIXME: Ick!
+            &var.clone()
+                .try_into_free_var()
+                .expect("encountered a bound variable"),
+        ) {
             Some(term) => Ok((*term).clone()),
-            None => Err(format!("`{:?}` not found", name)),
+            None => Err(format!("`{:?}` not found in `{:?}`", var, context)),
         },
-        Expr::Var(Var::Bound(ref name, _)) => panic!("encountered a bound variable: {:?}", name),
-        Expr::Lam(ref scope) => match scope.clone().unbind() {
-            ((name, Embed(Some(ann))), body) => {
-                let body_ty = infer(&context.insert(name, ann.clone()), &body)?;
-                Ok(RcType::from(Type::Arrow(ann, body_ty)))
-            },
-            ((name, Embed(None)), _) => {
-                Err(format!("type annotation needed for argument `{:?}`", name))
-            },
+        Expr::Lam(ref scope) => {
+            let (pattern, body) = scope.clone().unbind();
+            let (ann, bindings) = infer_pattern(context, &pattern)?;
+            let body_ty = infer_expr(&(context + &bindings), &body)?;
+            Ok(RcType::from(Type::Arrow(ann, body_ty)))
         },
-        Expr::App(ref fun, ref arg) => match *infer(context, fun)?.inner {
+        Expr::App(ref fun, ref arg) => match *infer_expr(context, fun)?.inner {
             Type::Arrow(ref param_ty, ref ret_ty) => {
-                let arg_ty = infer(context, arg)?;
+                let arg_ty = infer_expr(context, arg)?;
                 if RcType::term_eq(param_ty, &arg_ty) {
                     Ok(ret_ty.clone())
                 } else {
@@ -235,36 +340,229 @@ pub fn infer(context: &Context, expr: &RcExpr) -> Result<RcType, String> {
             },
             _ => Err(format!("`{:?}` is not a function", fun)),
         },
-        Expr::Record(ref elems) => Ok(RcType::from(Type::Record(
-            elems
+        Expr::Record(ref fields) => {
+            let fields = fields
                 .iter()
-                .map(|&(ref label, ref expr)| Ok((label.clone(), infer(context, expr)?)))
-                .collect::<Result<_, String>>()?,
-        ))),
-        Expr::Proj(ref expr, ref label) => match *infer(context, expr)?.inner {
-            Type::Record(ref elems) => match elems.iter().find(|&(l, _)| l == label) {
+                .map(|&(ref label, ref expr)| Ok((label.clone(), infer_expr(context, expr)?)))
+                .collect::<Result<_, String>>()?;
+
+            Ok(RcType::from(Type::Record(fields)))
+        },
+        Expr::Proj(ref expr, ref label) => match *infer_expr(context, expr)?.inner {
+            Type::Record(ref fields) => match fields.iter().find(|&(l, _)| l == label) {
                 Some(&(_, ref ty)) => Ok(ty.clone()),
                 None => Err(format!("field `{}` not found in type", label)),
             },
             _ => Err("record expected".to_string()),
         },
         Expr::Tag(_, _) => Err("type annotations needed".to_string()),
+        Expr::Case(_, _) => Err("type annotations needed".to_string()),
+    }
+}
+
+// TODO: Check pattern coverage/exhaustiveness (ie. if a series of patterns
+// cover all cases)
+
+/// Synthesize the types of unambiguous patterns
+///
+/// This function also returns a telescope that can be used to extend the typing
+/// context with additional bindings that the pattern introduces.
+pub fn check_pattern(
+    context: &Context,
+    pattern: &RcPattern,
+    expected_ty: &RcType,
+) -> Result<Context, String> {
+    match (&*pattern.inner, &*expected_ty.inner) {
+        (&Pattern::Var(ref var), _) => {
+            // FIXME: Ick!
+            let var = var
+                .clone()
+                .try_into_free_var()
+                .expect("encountered a bound variable");
+            return Ok(Context::new().insert(var.clone(), expected_ty.clone()));
+        },
+        (&Pattern::Tag(ref label, ref pattern), &Type::Variant(ref variants)) => {
+            return match variants.iter().find(|&(l, _)| l == label) {
+                None => Err(format!(
+                    "variant type did not contain the label `{}`",
+                    label
+                )),
+                Some(&(_, ref ty)) => check_pattern(context, pattern, ty),
+            };
+        },
+        (_, _) => {},
+    }
+
+    let (inferred_ty, telescope) = infer_pattern(&context, pattern)?;
+
+    // FIXME: allow out-of-order fields in records
+    if RcType::term_eq(&inferred_ty, expected_ty) {
+        Ok(telescope)
+    } else {
+        Err(format!(
+            "type mismatch - found `{:?}` but expected `{:?}`",
+            inferred_ty, expected_ty
+        ))
+    }
+}
+
+/// Check that a (potentially ambiguous) pattern conforms to a given type
+///
+/// This function also returns a telescope that can be used to extend the typing
+/// context with additional bindings that the pattern introduces.
+pub fn infer_pattern(context: &Context, expr: &RcPattern) -> Result<(RcType, Context), String> {
+    match *expr.inner {
+        Pattern::Ann(ref pattern, Embed(ref ty)) => {
+            let telescope = check_pattern(context, pattern, ty)?;
+            Ok((ty.clone(), telescope))
+        },
+        Pattern::Literal(Literal::Int(_)) => Ok((RcType::from(Type::Int), Context::new())),
+        Pattern::Literal(Literal::Float(_)) => Ok((RcType::from(Type::Float), Context::new())),
+        Pattern::Literal(Literal::String(_)) => Ok((RcType::from(Type::String), Context::new())),
+        Pattern::Var(_) => Err("type annotations needed".to_string()),
+        Pattern::Record(ref fields) => {
+            let mut telescope = Context::new();
+
+            let fields = fields
+                .iter()
+                .map(|&(ref label, ref pattern)| {
+                    let (pattern_ty, pattern_telescope) = infer_pattern(context, pattern)?;
+                    telescope.extend(pattern_telescope);
+                    Ok((label.clone(), pattern_ty))
+                })
+                .collect::<Result<_, String>>()?;
+
+            Ok((RcType::from(Type::Record(fields)), telescope))
+        },
+        Pattern::Tag(_, _) => Err("type annotations needed".to_string()),
     }
 }
 
 #[test]
-fn test_infer() {
+fn test_infer_expr() {
     // expr = (\x : Int -> x)
     let expr = RcExpr::from(Expr::Lam(Scope::new(
-        (FreeVar::user("x"), Embed(Some(RcType::from(Type::Int)))),
-        RcExpr::from(Expr::Var(Var::user("x"))),
+        RcPattern::from(Pattern::Ann(
+            RcPattern::from(Pattern::Var(PVar::user("x"))),
+            Embed(RcType::from(Type::Int)),
+        )),
+        RcExpr::from(Expr::Var(TVar::user("x"))),
     )));
 
     assert_term_eq!(
-        infer(&Context::new(), &expr).unwrap(),
+        infer_expr(&Context::new(), &expr).unwrap(),
         RcType::from(Type::Arrow(
             RcType::from(Type::Int),
             RcType::from(Type::Int)
+        )),
+    );
+}
+
+#[test]
+fn test_infer_app_expr() {
+    // expr = (\x -> x : Int -> Int) 1
+    let expr = RcExpr::from(Expr::App(
+        RcExpr::from(Expr::Ann(
+            RcExpr::from(Expr::Lam(Scope::new(
+                RcPattern::from(Pattern::Var(PVar::user("x"))),
+                RcExpr::from(Expr::Var(TVar::user("x"))),
+            ))),
+            RcType::from(Type::Arrow(
+                RcType::from(Type::Int),
+                RcType::from(Type::Int),
+            )),
+        )),
+        RcExpr::from(Expr::Literal(Literal::Int(1))),
+    ));
+
+    assert_term_eq!(
+        infer_expr(&Context::new(), &expr).unwrap(),
+        RcType::from(Type::Int),
+    );
+}
+
+#[test]
+fn test_infer_expr_record1() {
+    // expr = \{ x = a : Int, y = b : String } -> b
+    let expr = RcExpr::from(Expr::Lam(Scope::new(
+        RcPattern::from(Pattern::Record(vec![
+            (
+                String::from("x"),
+                RcPattern::from(Pattern::Ann(
+                    RcPattern::from(Pattern::Var(PVar::user("a"))),
+                    Embed(RcType::from(Type::Int)),
+                )),
+            ),
+            (
+                String::from("y"),
+                RcPattern::from(Pattern::Ann(
+                    RcPattern::from(Pattern::Var(PVar::user("b"))),
+                    Embed(RcType::from(Type::String)),
+                )),
+            ),
+        ])),
+        RcExpr::from(Expr::Var(TVar::user("b"))),
+    )));
+
+    assert_term_eq!(
+        infer_expr(&Context::new(), &expr).unwrap(),
+        RcType::from(Type::Arrow(
+            RcType::from(Type::Record(vec![
+                (String::from("x"), RcType::from(Type::Int)),
+                (String::from("y"), RcType::from(Type::String)),
+            ])),
+            RcType::from(Type::String),
+        )),
+    );
+}
+
+#[test]
+fn test_infer_expr_record2() {
+    // expr = \{ x = a : Int, y = b : String, z = c : Float } -> { x = a, y = b, z = c }
+    let expr = RcExpr::from(Expr::Lam(Scope::new(
+        RcPattern::from(Pattern::Record(vec![
+            (
+                String::from("x"),
+                RcPattern::from(Pattern::Ann(
+                    RcPattern::from(Pattern::Var(PVar::user("a"))),
+                    Embed(RcType::from(Type::Int)),
+                )),
+            ),
+            (
+                String::from("y"),
+                RcPattern::from(Pattern::Ann(
+                    RcPattern::from(Pattern::Var(PVar::user("b"))),
+                    Embed(RcType::from(Type::String)),
+                )),
+            ),
+            (
+                String::from("z"),
+                RcPattern::from(Pattern::Ann(
+                    RcPattern::from(Pattern::Var(PVar::user("c"))),
+                    Embed(RcType::from(Type::Float)),
+                )),
+            ),
+        ])),
+        RcExpr::from(Expr::Record(vec![
+            (String::from("x"), RcExpr::from(Expr::Var(TVar::user("a")))),
+            (String::from("y"), RcExpr::from(Expr::Var(TVar::user("b")))),
+            (String::from("z"), RcExpr::from(Expr::Var(TVar::user("c")))),
+        ])),
+    )));
+
+    assert_term_eq!(
+        infer_expr(&Context::new(), &expr).unwrap(),
+        RcType::from(Type::Arrow(
+            RcType::from(Type::Record(vec![
+                (String::from("x"), RcType::from(Type::Int)),
+                (String::from("y"), RcType::from(Type::String)),
+                (String::from("z"), RcType::from(Type::Float)),
+            ])),
+            RcType::from(Type::Record(vec![
+                (String::from("x"), RcType::from(Type::Int)),
+                (String::from("y"), RcType::from(Type::String)),
+                (String::from("z"), RcType::from(Type::Float)),
+            ])),
         )),
     );
 }

--- a/moniker/src/bound.rs
+++ b/moniker/src/bound.rs
@@ -57,44 +57,6 @@ pub trait BoundTerm<Ident> {
     }
 }
 
-/// Asserts that two expressions are alpha equivalent to each other (using
-/// `BoundTerm::term_eq`).
-///
-/// On panic, this macro will print the values of the expressions with their
-/// debug representations.
-///
-/// Like `assert!`, this macro has a second form, where a custom
-/// panic message can be provided.
-#[macro_export]
-macro_rules! assert_term_eq {
-    ($left:expr, $right:expr) => ({
-        match (&$left, &$right) {
-            (left_val, right_val) => {
-                if !::moniker::BoundTerm::term_eq(left_val, right_val) {
-                    panic!(r#"assertion failed: `<_>::term_eq(&left, &right)`
-  left: `{:?}`,
- right: `{:?}`"#, left_val, right_val)
-                }
-            }
-        }
-    });
-    ($left:expr, $right:expr,) => ({
-        assert_term_eq!($left, $right)
-    });
-    ($left:expr, $right:expr, $($arg:tt)+) => ({
-        match (&($left), &($right)) {
-            (left_val, right_val) => {
-                if !::moniker::BoundTerm::term_eq(left_val, right_val) {
-                    panic!(r#"assertion failed: `<_>::term_eq(&left, &right)`
-  left: `{:?}`,
- right: `{:?}`: {}"#, left_val, right_val,
-                           format_args!($($arg)+))
-                }
-            }
-        }
-    });
-}
-
 impl<Ident: PartialEq> BoundTerm<Ident> for FreeVar<Ident> {
     fn term_eq(&self, other: &FreeVar<Ident>) -> bool {
         match (self, other) {
@@ -514,44 +476,6 @@ pub trait BoundPattern<Ident> {
     /// A callback that is used when `bind`ing `Bind`s to replace bound names
     /// with free names based on the contents of the pattern
     fn on_bound(&self, state: ScopeState, name: BoundVar) -> Option<FreeVar<Ident>>;
-}
-
-/// Asserts that two expressions are alpha equivalent to each other (using
-/// `BoundPattern::pattern_eq`).
-///
-/// On panic, this macro will print the values of the expressions with their
-/// debug representations.
-///
-/// Like `assert!`, this macro has a second form, where a custom
-/// panic message can be provided.
-#[macro_export]
-macro_rules! assert_pattern_eq {
-    ($left:expr, $right:expr) => ({
-        match (&$left, &$right) {
-            (left_val, right_val) => {
-                if !::moniker::BoundPattern::pattern_eq(left_val, right_val) {
-                    panic!(r#"assertion failed: `<_>::pattern_eq(&left, &right)`
-  left: `{:?}`,
- right: `{:?}`"#, left_val, right_val)
-                }
-            }
-        }
-    });
-    ($left:expr, $right:expr,) => ({
-        assert_pattern_eq!($left, $right)
-    });
-    ($left:expr, $right:expr, $($arg:tt)+) => ({
-        match (&($left), &($right)) {
-            (left_val, right_val) => {
-                if !::moniker::BoundPattern::pattern_eq(left_val, right_val) {
-                    panic!(r#"assertion failed: `<_>::pattern_eq(&left, &right)`
-  left: `{:?}`,
- right: `{:?}`: {}"#, left_val, right_val,
-                           format_args!($($arg)+))
-                }
-            }
-        }
-    });
 }
 
 impl<Ident: Clone + PartialEq> BoundPattern<Ident> for FreeVar<Ident> {

--- a/moniker/src/bound.rs
+++ b/moniker/src/bound.rs
@@ -3,13 +3,12 @@ use codespan::{
     ByteIndex, ByteOffset, ColumnIndex, ColumnNumber, ColumnOffset, LineIndex, LineNumber,
     LineOffset, Span,
 };
-use std::collections::HashSet;
+use std::collections::{HashMap, HashSet};
 use std::hash::Hash;
 use std::rc::Rc;
 use std::sync::Arc;
-use std::{slice, vec};
 
-use var::{BoundVar, FreeVar, GenId, PatternIndex, ScopeOffset, Var};
+use var::{FreeVar, PVar, PVarIndex, PVarOffset, ScopeOffset, TVar};
 
 #[derive(Debug, Copy, Clone)]
 pub struct ScopeState {
@@ -31,6 +30,7 @@ impl ScopeState {
     }
 }
 
+/// Terms that may contain variables that can be bound by patterns
 pub trait BoundTerm<Ident> {
     /// Alpha equivalence in a term context
     fn term_eq(&self, other: &Self) -> bool;
@@ -39,19 +39,20 @@ pub trait BoundTerm<Ident> {
 
     fn open_term(&mut self, state: ScopeState, pattern: &impl BoundPattern<Ident>);
 
-    fn visit_vars(&self, on_var: &mut impl FnMut(&Var<Ident>));
+    fn visit_vars(&self, on_var: &mut impl FnMut(&TVar<Ident>));
 
-    fn visit_mut_vars(&mut self, on_var: &mut impl FnMut(&mut Var<Ident>));
+    fn visit_mut_vars(&mut self, on_var: &mut impl FnMut(&mut TVar<Ident>));
 
+    /// Returns the set of free variables in this term
     fn free_vars(&self) -> HashSet<FreeVar<Ident>>
     where
         Ident: Eq + Hash + Clone,
     {
         let mut free_vars = HashSet::new();
         self.visit_vars(&mut |var| match *var {
-            Var::Bound(_, _) => {},
-            Var::Free(ref name) => {
-                free_vars.insert(name.clone());
+            TVar::Bound(_, _, _) => {},
+            TVar::Free(ref free_var) => {
+                free_vars.insert(free_var.clone());
             },
         });
         free_vars
@@ -60,56 +61,58 @@ pub trait BoundTerm<Ident> {
 
 impl<Ident: PartialEq> BoundTerm<Ident> for FreeVar<Ident> {
     fn term_eq(&self, other: &FreeVar<Ident>) -> bool {
-        match (self, other) {
-            (&FreeVar::User(ref lhs), &FreeVar::User(ref rhs)) => lhs == rhs,
-            (&FreeVar::Gen(ref lhs, _), &FreeVar::Gen(ref rhs, _)) => lhs == rhs,
-            _ => false,
-        }
+        self == other
     }
 
     fn close_term(&mut self, _: ScopeState, _: &impl BoundPattern<Ident>) {}
 
     fn open_term(&mut self, _: ScopeState, _: &impl BoundPattern<Ident>) {}
 
-    fn visit_vars(&self, _: &mut impl FnMut(&Var<Ident>)) {}
+    fn visit_vars(&self, _: &mut impl FnMut(&TVar<Ident>)) {}
 
-    fn visit_mut_vars(&mut self, _: &mut impl FnMut(&mut Var<Ident>)) {}
+    fn visit_mut_vars(&mut self, _: &mut impl FnMut(&mut TVar<Ident>)) {}
 }
 
-impl<Ident: PartialEq + Clone> BoundTerm<Ident> for Var<Ident> {
-    fn term_eq(&self, other: &Var<Ident>) -> bool {
-        match (self, other) {
-            (&Var::Free(ref lhs), &Var::Free(ref rhs)) => FreeVar::term_eq(lhs, rhs),
-            (&Var::Bound(ref lhs, _), &Var::Bound(ref rhs, _)) => lhs == rhs,
-            (_, _) => false,
-        }
+impl<Ident: PartialEq + Clone> BoundTerm<Ident> for TVar<Ident> {
+    fn term_eq(&self, other: &TVar<Ident>) -> bool {
+        self == other
     }
 
     fn close_term(&mut self, state: ScopeState, pattern: &impl BoundPattern<Ident>) {
+        // NOTE: Working around NLL
         *self = match *self {
-            Var::Bound(_, _) => return,
-            Var::Free(ref name) => match pattern.on_free(state, name) {
-                Some(bound) => Var::Bound(bound, name.ident().cloned()),
-                None => return,
+            TVar::Bound(_, _, _) => return,
+            TVar::Free(ref free_var) => match pattern.find_pvar_index(free_var) {
+                Ok(pvar_index) => TVar::Bound(state.depth(), pvar_index, free_var.ident().cloned()),
+                Err(_) => return,
             },
         };
     }
 
     fn open_term(&mut self, state: ScopeState, pattern: &impl BoundPattern<Ident>) {
+        // NOTE: Working around NLL
         *self = match *self {
-            Var::Free(_) => return,
-            Var::Bound(bound, _) => match pattern.on_bound(state, bound) {
-                Some(name) => Var::Free(name),
-                None => return,
+            TVar::Bound(scope, pvar_index, _) if scope == state.depth() => {
+                match pattern.find_pvar_at_offset(pvar_index.0) {
+                    Ok(pvar) => pvar.to_var(state.depth()),
+                    Err(_) => {
+                        // FIXME: better error?
+                        panic!(
+                            "too few variables in pattern: expected at least {}",
+                            pvar_index,
+                        );
+                    },
+                }
             },
+            TVar::Bound(_, _, _) | TVar::Free(_) => return,
         };
     }
 
-    fn visit_vars(&self, on_var: &mut impl FnMut(&Var<Ident>)) {
+    fn visit_vars(&self, on_var: &mut impl FnMut(&TVar<Ident>)) {
         on_var(self);
     }
 
-    fn visit_mut_vars(&mut self, on_var: &mut impl FnMut(&mut Var<Ident>)) {
+    fn visit_mut_vars(&mut self, on_var: &mut impl FnMut(&mut TVar<Ident>)) {
         on_var(self);
     }
 }
@@ -127,9 +130,9 @@ macro_rules! impl_bound_term_partial_eq {
 
             fn open_term(&mut self, _: ScopeState, _: &impl BoundPattern<Ident>) {}
 
-            fn visit_vars(&self, _: &mut impl FnMut(&Var<Ident>)) {}
+            fn visit_vars(&self, _: &mut impl FnMut(&TVar<Ident>)) {}
 
-            fn visit_mut_vars(&mut self, _: &mut impl FnMut(&mut Var<Ident>)) {}
+            fn visit_mut_vars(&mut self, _: &mut impl FnMut(&mut TVar<Ident>)) {}
         }
     };
 }
@@ -164,9 +167,9 @@ macro_rules! impl_bound_term_ignore {
 
             fn open_term(&mut self, _: ScopeState, _: &impl BoundPattern<Ident>) {}
 
-            fn visit_vars(&self, _: &mut impl FnMut(&Var<Ident>)) {}
+            fn visit_vars(&self, _: &mut impl FnMut(&TVar<Ident>)) {}
 
-            fn visit_mut_vars(&mut self, _: &mut impl FnMut(&mut Var<Ident>)) {}
+            fn visit_mut_vars(&mut self, _: &mut impl FnMut(&mut TVar<Ident>)) {}
         }
     };
 }
@@ -198,9 +201,9 @@ impl<Ident, T> BoundTerm<Ident> for Span<T> {
 
     fn open_term(&mut self, _: ScopeState, _: &impl BoundPattern<Ident>) {}
 
-    fn visit_vars(&self, _: &mut impl FnMut(&Var<Ident>)) {}
+    fn visit_vars(&self, _: &mut impl FnMut(&TVar<Ident>)) {}
 
-    fn visit_mut_vars(&mut self, _: &mut impl FnMut(&mut Var<Ident>)) {}
+    fn visit_mut_vars(&mut self, _: &mut impl FnMut(&mut TVar<Ident>)) {}
 }
 
 impl<Ident, T> BoundTerm<Ident> for Option<T>
@@ -227,13 +230,13 @@ where
         }
     }
 
-    fn visit_vars(&self, on_var: &mut impl FnMut(&Var<Ident>)) {
+    fn visit_vars(&self, on_var: &mut impl FnMut(&TVar<Ident>)) {
         if let Some(ref inner) = *self {
             inner.visit_vars(on_var);
         }
     }
 
-    fn visit_mut_vars(&mut self, on_var: &mut impl FnMut(&mut Var<Ident>)) {
+    fn visit_mut_vars(&mut self, on_var: &mut impl FnMut(&mut TVar<Ident>)) {
         if let Some(ref mut inner) = *self {
             inner.visit_mut_vars(on_var);
         }
@@ -256,11 +259,11 @@ where
         T::open_term(self, state, pattern);
     }
 
-    fn visit_vars(&self, on_var: &mut impl FnMut(&Var<Ident>)) {
+    fn visit_vars(&self, on_var: &mut impl FnMut(&TVar<Ident>)) {
         T::visit_vars(self, on_var);
     }
 
-    fn visit_mut_vars(&mut self, on_var: &mut impl FnMut(&mut Var<Ident>)) {
+    fn visit_mut_vars(&mut self, on_var: &mut impl FnMut(&mut TVar<Ident>)) {
         T::visit_mut_vars(self, on_var);
     }
 }
@@ -281,11 +284,11 @@ where
         T::open_term(Rc::make_mut(self), state, pattern);
     }
 
-    fn visit_vars(&self, on_var: &mut impl FnMut(&Var<Ident>)) {
+    fn visit_vars(&self, on_var: &mut impl FnMut(&TVar<Ident>)) {
         T::visit_vars(self, on_var);
     }
 
-    fn visit_mut_vars(&mut self, on_var: &mut impl FnMut(&mut Var<Ident>)) {
+    fn visit_mut_vars(&mut self, on_var: &mut impl FnMut(&mut TVar<Ident>)) {
         T::visit_mut_vars(Rc::make_mut(self), on_var);
     }
 }
@@ -306,11 +309,11 @@ where
         T::open_term(Arc::make_mut(self), state, pattern);
     }
 
-    fn visit_vars(&self, on_var: &mut impl FnMut(&Var<Ident>)) {
+    fn visit_vars(&self, on_var: &mut impl FnMut(&TVar<Ident>)) {
         T::visit_vars(self, on_var);
     }
 
-    fn visit_mut_vars(&mut self, on_var: &mut impl FnMut(&mut Var<Ident>)) {
+    fn visit_mut_vars(&mut self, on_var: &mut impl FnMut(&mut TVar<Ident>)) {
         T::visit_mut_vars(Arc::make_mut(self), on_var);
     }
 }
@@ -334,12 +337,12 @@ where
         self.1.open_term(state, pattern);
     }
 
-    fn visit_vars(&self, on_var: &mut impl FnMut(&Var<Ident>)) {
+    fn visit_vars(&self, on_var: &mut impl FnMut(&TVar<Ident>)) {
         self.0.visit_vars(on_var);
         self.1.visit_vars(on_var);
     }
 
-    fn visit_mut_vars(&mut self, on_var: &mut impl FnMut(&mut Var<Ident>)) {
+    fn visit_mut_vars(&mut self, on_var: &mut impl FnMut(&mut TVar<Ident>)) {
         self.0.visit_mut_vars(on_var);
         self.1.visit_mut_vars(on_var);
     }
@@ -369,13 +372,13 @@ where
         self.2.open_term(state, pattern);
     }
 
-    fn visit_vars(&self, on_var: &mut impl FnMut(&Var<Ident>)) {
+    fn visit_vars(&self, on_var: &mut impl FnMut(&TVar<Ident>)) {
         self.0.visit_vars(on_var);
         self.1.visit_vars(on_var);
         self.2.visit_vars(on_var);
     }
 
-    fn visit_mut_vars(&mut self, on_var: &mut impl FnMut(&mut Var<Ident>)) {
+    fn visit_mut_vars(&mut self, on_var: &mut impl FnMut(&mut TVar<Ident>)) {
         self.0.visit_mut_vars(on_var);
         self.1.visit_mut_vars(on_var);
         self.2.visit_mut_vars(on_var);
@@ -403,13 +406,13 @@ where
         }
     }
 
-    fn visit_vars(&self, on_var: &mut impl FnMut(&Var<Ident>)) {
+    fn visit_vars(&self, on_var: &mut impl FnMut(&TVar<Ident>)) {
         for elem in self {
             elem.visit_vars(on_var);
         }
     }
 
-    fn visit_mut_vars(&mut self, on_var: &mut impl FnMut(&mut Var<Ident>)) {
+    fn visit_mut_vars(&mut self, on_var: &mut impl FnMut(&mut TVar<Ident>)) {
         for elem in self {
             elem.visit_mut_vars(on_var);
         }
@@ -432,120 +435,82 @@ where
         <[T]>::open_term(self, state, pattern)
     }
 
-    fn visit_vars(&self, on_var: &mut impl FnMut(&Var<Ident>)) {
+    fn visit_vars(&self, on_var: &mut impl FnMut(&TVar<Ident>)) {
         <[T]>::visit_vars(self, on_var);
     }
 
-    fn visit_mut_vars(&mut self, on_var: &mut impl FnMut(&mut Var<Ident>)) {
+    fn visit_mut_vars(&mut self, on_var: &mut impl FnMut(&mut TVar<Ident>)) {
         <[T]>::visit_mut_vars(self, on_var);
     }
 }
 
-/// A mapping of `PatternIndex`s to `T`s
-pub struct PatternSubsts<T> {
-    permutations: Vec<T>,
-}
+pub type Permutations<Ident> = HashMap<PVar<Ident>, PVar<Ident>>;
 
-impl<T> PatternSubsts<T> {
-    pub fn new(permutations: Vec<T>) -> PatternSubsts<T> {
-        PatternSubsts { permutations }
-    }
-
-    pub fn lookup(&self, index: PatternIndex) -> Option<&T> {
-        self.permutations.get(index.0 as usize)
-    }
-
-    pub fn push(&mut self, value: T) {
-        self.permutations.push(value);
-    }
-
-    pub fn len(&self) -> usize {
-        self.permutations.len()
-    }
-
-    pub fn iter(&self) -> slice::Iter<T> {
-        self.permutations.iter()
-    }
-}
-
-impl<T> Extend<T> for PatternSubsts<T> {
-    fn extend<I: IntoIterator<Item = T>>(&mut self, iter: I) {
-        self.permutations.extend(iter)
-    }
-}
-
-impl<T> IntoIterator for PatternSubsts<T> {
-    type Item = T;
-    type IntoIter = vec::IntoIter<T>;
-
-    fn into_iter(self) -> vec::IntoIter<T> {
-        self.permutations.into_iter()
-    }
-}
-
+/// Patterns that bind variables in terms
 pub trait BoundPattern<Ident> {
     /// Alpha equivalence in a pattern context
     fn pattern_eq(&self, other: &Self) -> bool;
 
-    fn freshen(&mut self, permutations: &mut PatternSubsts<FreeVar<Ident>>);
+    fn freshen(&mut self, permutations: &mut Permutations<Ident>);
 
-    fn swaps(&mut self, permutations: &PatternSubsts<FreeVar<Ident>>);
+    fn swaps(&mut self, permutations: &Permutations<Ident>);
 
     fn close_pattern(&mut self, state: ScopeState, pattern: &impl BoundPattern<Ident>);
 
     fn open_pattern(&mut self, state: ScopeState, pattern: &impl BoundPattern<Ident>);
 
-    /// A callback that is used when `unbind`ing `Bind`s to replace free names
-    /// with bound names based on the contents of the pattern
-    fn on_free(&self, state: ScopeState, name: &FreeVar<Ident>) -> Option<BoundVar>;
+    /// Find the index of the pattern that binds the given free variable
+    ///
+    /// If we failed to find a pattern variable corresponding to the free
+    /// variable we return a pattern variable offset describing how many
+    /// pattern variables we passed over.
+    fn find_pvar_index(&self, free_var: &FreeVar<Ident>) -> Result<PVarIndex, PVarOffset>;
 
-    /// A callback that is used when `bind`ing `Bind`s to replace bound names
-    /// with free names based on the contents of the pattern
-    fn on_bound(&self, state: ScopeState, name: BoundVar) -> Option<FreeVar<Ident>>;
+    /// Find the pattern variable at the given offset
+    ///
+    /// If we finished traversing over the pattern without finding a pattern
+    /// we return the offset that still remains.
+    fn find_pvar_at_offset(&self, offset: PVarOffset) -> Result<PVar<Ident>, PVarOffset>;
 }
 
-impl<Ident: Clone + PartialEq> BoundPattern<Ident> for FreeVar<Ident> {
-    fn pattern_eq(&self, _other: &FreeVar<Ident>) -> bool {
+impl<Ident> BoundPattern<Ident> for PVar<Ident>
+where
+    Ident: Clone + Eq + Hash,
+{
+    fn pattern_eq(&self, _: &PVar<Ident>) -> bool {
         true
     }
 
-    fn freshen(&mut self, permutations: &mut PatternSubsts<FreeVar<Ident>>) {
-        *self = match *self {
-            FreeVar::User(ref name) => FreeVar::Gen(GenId::fresh(), Some(name.clone())),
-            FreeVar::Gen(_, _) => {
-                permutations.push(self.clone());
-                return;
-            },
-        };
-        permutations.push(self.clone());
+    fn freshen(&mut self, permutations: &mut Permutations<Ident>) {
+        let fresh = self.clone().fresh();
+        permutations.insert(self.clone(), fresh.clone());
+        *self = fresh;
     }
 
-    fn swaps(&mut self, permutations: &PatternSubsts<FreeVar<Ident>>) {
-        assert_eq!(permutations.len(), 1); // FIXME: assert
-        *self = permutations.lookup(PatternIndex(0)).unwrap().clone(); // FIXME: double clone
+    fn swaps(&mut self, permutations: &Permutations<Ident>) {
+        *self = permutations
+            .get(self)
+            .cloned()
+            // TODO: better error here?
+            .expect("pattern not found in permutation");
     }
 
     fn close_pattern(&mut self, _: ScopeState, _: &impl BoundPattern<Ident>) {}
 
     fn open_pattern(&mut self, _: ScopeState, _: &impl BoundPattern<Ident>) {}
 
-    fn on_free(&self, state: ScopeState, name: &FreeVar<Ident>) -> Option<BoundVar> {
-        match FreeVar::term_eq(name, self) {
-            true => Some(BoundVar {
-                scope: state.depth(),
-                pattern: PatternIndex(0),
-            }),
-            false => None,
+    fn find_pvar_index(&self, free_var: &FreeVar<Ident>) -> Result<PVarIndex, PVarOffset> {
+        match *self {
+            PVar::Free(ref n) if n == free_var => Ok(PVarIndex(PVarOffset(0))),
+            PVar::Free(_) | PVar::Bound(_, _) => Err(PVarOffset(1)),
         }
     }
 
-    fn on_bound(&self, state: ScopeState, name: BoundVar) -> Option<FreeVar<Ident>> {
-        match name.scope == state.depth() {
-            true => {
-                assert_eq!(name.pattern, PatternIndex(0));
-                Some(self.clone())
-            },
-            false => None,
+    fn find_pvar_at_offset(&self, offset: PVarOffset) -> Result<PVar<Ident>, PVarOffset> {
+        if offset == PVarOffset(0) {
+            Ok(self.clone())
+        } else {
+            Err(offset - PVarOffset(1))
         }
     }
 }
@@ -559,20 +524,20 @@ macro_rules! impl_bound_pattern_partial_eq {
                 self == other
             }
 
-            fn freshen(&mut self, _: &mut PatternSubsts<FreeVar<Ident>>) {}
+            fn freshen(&mut self, _: &mut Permutations<Ident>) {}
 
-            fn swaps(&mut self, _: &PatternSubsts<FreeVar<Ident>>) {}
+            fn swaps(&mut self, _: &Permutations<Ident>) {}
 
             fn close_pattern(&mut self, _: ScopeState, _: &impl BoundPattern<Ident>) {}
 
             fn open_pattern(&mut self, _: ScopeState, _: &impl BoundPattern<Ident>) {}
 
-            fn on_free(&self, _: ScopeState, _: &FreeVar<Ident>) -> Option<BoundVar> {
-                None
+            fn find_pvar_index(&self, _: &FreeVar<Ident>) -> Result<PVarIndex, PVarOffset> {
+                Err(PVarOffset(0))
             }
 
-            fn on_bound(&self, _: ScopeState, _: BoundVar) -> Option<FreeVar<Ident>> {
-                None
+            fn find_pvar_at_offset(&self, offset: PVarOffset) -> Result<PVar<Ident>, PVarOffset> {
+                Err(offset)
             }
         }
     };
@@ -604,20 +569,20 @@ macro_rules! impl_bound_pattern_ignore {
                 true
             }
 
-            fn freshen(&mut self, _: &mut PatternSubsts<FreeVar<Ident>>) {}
+            fn freshen(&mut self, _: &mut Permutations<Ident>) {}
 
-            fn swaps(&mut self, _: &PatternSubsts<FreeVar<Ident>>) {}
+            fn swaps(&mut self, _: &Permutations<Ident>) {}
 
             fn close_pattern(&mut self, _: ScopeState, _: &impl BoundPattern<Ident>) {}
 
             fn open_pattern(&mut self, _: ScopeState, _: &impl BoundPattern<Ident>) {}
 
-            fn on_free(&self, _: ScopeState, _: &FreeVar<Ident>) -> Option<BoundVar> {
-                None
+            fn find_pvar_index(&self, _: &FreeVar<Ident>) -> Result<PVarIndex, PVarOffset> {
+                Err(PVarOffset(0))
             }
 
-            fn on_bound(&self, _: ScopeState, _: BoundVar) -> Option<FreeVar<Ident>> {
-                None
+            fn find_pvar_at_offset(&self, offset: PVarOffset) -> Result<PVar<Ident>, PVarOffset> {
+                Err(offset)
             }
         }
     };
@@ -646,20 +611,20 @@ impl<Ident, T> BoundPattern<Ident> for Span<T> {
         true
     }
 
-    fn freshen(&mut self, _: &mut PatternSubsts<FreeVar<Ident>>) {}
+    fn freshen(&mut self, _: &mut Permutations<Ident>) {}
 
-    fn swaps(&mut self, _: &PatternSubsts<FreeVar<Ident>>) {}
+    fn swaps(&mut self, _: &Permutations<Ident>) {}
 
     fn close_pattern(&mut self, _: ScopeState, _: &impl BoundPattern<Ident>) {}
 
     fn open_pattern(&mut self, _: ScopeState, _: &impl BoundPattern<Ident>) {}
 
-    fn on_free(&self, _: ScopeState, _: &FreeVar<Ident>) -> Option<BoundVar> {
-        None
+    fn find_pvar_index(&self, _: &FreeVar<Ident>) -> Result<PVarIndex, PVarOffset> {
+        Err(PVarOffset(0))
     }
 
-    fn on_bound(&self, _: ScopeState, _: BoundVar) -> Option<FreeVar<Ident>> {
-        None
+    fn find_pvar_at_offset(&self, offset: PVarOffset) -> Result<PVar<Ident>, PVarOffset> {
+        Err(offset)
     }
 }
 
@@ -675,13 +640,13 @@ where
         }
     }
 
-    fn freshen(&mut self, permutations: &mut PatternSubsts<FreeVar<Ident>>) {
+    fn freshen(&mut self, permutations: &mut Permutations<Ident>) {
         if let Some(ref mut inner) = *self {
             inner.freshen(permutations);
         }
     }
 
-    fn swaps(&mut self, permutations: &PatternSubsts<FreeVar<Ident>>) {
+    fn swaps(&mut self, permutations: &Permutations<Ident>) {
         if let Some(ref mut inner) = *self {
             inner.swaps(permutations);
         }
@@ -699,12 +664,18 @@ where
         }
     }
 
-    fn on_free(&self, state: ScopeState, name: &FreeVar<Ident>) -> Option<BoundVar> {
-        self.as_ref().and_then(|inner| inner.on_free(state, name))
+    fn find_pvar_index(&self, free_var: &FreeVar<Ident>) -> Result<PVarIndex, PVarOffset> {
+        match *self {
+            None => Err(PVarOffset(0)),
+            Some(ref inner) => inner.find_pvar_index(free_var),
+        }
     }
 
-    fn on_bound(&self, state: ScopeState, name: BoundVar) -> Option<FreeVar<Ident>> {
-        self.as_ref().and_then(|inner| inner.on_bound(state, name))
+    fn find_pvar_at_offset(&self, offset: PVarOffset) -> Result<PVar<Ident>, PVarOffset> {
+        match *self {
+            None => Err(offset),
+            Some(ref inner) => inner.find_pvar_at_offset(offset),
+        }
     }
 }
 
@@ -717,12 +688,12 @@ where
         P1::pattern_eq(&self.0, &other.0) && P2::pattern_eq(&self.1, &other.1)
     }
 
-    fn freshen(&mut self, permutations: &mut PatternSubsts<FreeVar<Ident>>) {
+    fn freshen(&mut self, permutations: &mut Permutations<Ident>) {
         self.0.freshen(permutations);
         self.1.freshen(permutations);
     }
 
-    fn swaps(&mut self, permutations: &PatternSubsts<FreeVar<Ident>>) {
+    fn swaps(&mut self, permutations: &Permutations<Ident>) {
         self.0.swaps(permutations);
         self.1.swaps(permutations);
     }
@@ -737,16 +708,32 @@ where
         self.1.open_pattern(state, pattern);
     }
 
-    fn on_free(&self, state: ScopeState, name: &FreeVar<Ident>) -> Option<BoundVar> {
-        self.0
-            .on_free(state, name)
-            .or_else(|| self.1.on_free(state, name))
+    fn find_pvar_index(&self, free_var: &FreeVar<Ident>) -> Result<PVarIndex, PVarOffset> {
+        let mut skipped = PVarOffset(0);
+
+        match self.0.find_pvar_index(free_var) {
+            Ok(pvar_index) => return Ok(pvar_index + skipped),
+            Err(next_skipped) => skipped += next_skipped,
+        }
+        match self.1.find_pvar_index(free_var) {
+            Ok(pvar_index) => return Ok(pvar_index + skipped),
+            Err(next_skipped) => skipped += next_skipped,
+        }
+
+        Err(skipped)
     }
 
-    fn on_bound(&self, state: ScopeState, name: BoundVar) -> Option<FreeVar<Ident>> {
-        self.0
-            .on_bound(state, name)
-            .or_else(|| self.1.on_bound(state, name))
+    fn find_pvar_at_offset(&self, mut offset: PVarOffset) -> Result<PVar<Ident>, PVarOffset> {
+        match self.0.find_pvar_at_offset(offset) {
+            Ok(pvar) => return Ok(pvar),
+            Err(next_offset) => offset = next_offset,
+        }
+        match self.1.find_pvar_at_offset(offset) {
+            Ok(pvar) => return Ok(pvar),
+            Err(next_offset) => offset = next_offset,
+        }
+
+        Err(offset)
     }
 }
 
@@ -758,12 +745,12 @@ where
         P::pattern_eq(self, other)
     }
 
-    fn freshen(&mut self, permutations: &mut PatternSubsts<FreeVar<Ident>>) {
+    fn freshen(&mut self, permutations: &mut Permutations<Ident>) {
         P::freshen(self, permutations)
     }
 
-    fn swaps(&mut self, permutations: &PatternSubsts<FreeVar<Ident>>) {
-        P::swaps(self, permutations);
+    fn swaps(&mut self, permutations: &Permutations<Ident>) {
+        P::swaps(self, permutations)
     }
 
     fn close_pattern(&mut self, state: ScopeState, pattern: &impl BoundPattern<Ident>) {
@@ -774,12 +761,12 @@ where
         P::open_pattern(self, state, pattern);
     }
 
-    fn on_free(&self, state: ScopeState, name: &FreeVar<Ident>) -> Option<BoundVar> {
-        P::on_free(self, state, name)
+    fn find_pvar_index(&self, free_var: &FreeVar<Ident>) -> Result<PVarIndex, PVarOffset> {
+        P::find_pvar_index(self, free_var)
     }
 
-    fn on_bound(&self, state: ScopeState, name: BoundVar) -> Option<FreeVar<Ident>> {
-        P::on_bound(self, state, name)
+    fn find_pvar_at_offset(&self, offset: PVarOffset) -> Result<PVar<Ident>, PVarOffset> {
+        P::find_pvar_at_offset(self, offset)
     }
 }
 
@@ -791,12 +778,12 @@ where
         P::pattern_eq(self, other)
     }
 
-    fn freshen(&mut self, permutations: &mut PatternSubsts<FreeVar<Ident>>) {
+    fn freshen(&mut self, permutations: &mut Permutations<Ident>) {
         P::freshen(Rc::make_mut(self), permutations)
     }
 
-    fn swaps(&mut self, permutations: &PatternSubsts<FreeVar<Ident>>) {
-        P::swaps(Rc::make_mut(self), permutations);
+    fn swaps(&mut self, permutations: &Permutations<Ident>) {
+        P::swaps(Rc::make_mut(self), permutations)
     }
 
     fn close_pattern(&mut self, state: ScopeState, pattern: &impl BoundPattern<Ident>) {
@@ -807,12 +794,12 @@ where
         P::open_pattern(Rc::make_mut(self), state, pattern);
     }
 
-    fn on_free(&self, state: ScopeState, name: &FreeVar<Ident>) -> Option<BoundVar> {
-        P::on_free(self, state, name)
+    fn find_pvar_index(&self, free_var: &FreeVar<Ident>) -> Result<PVarIndex, PVarOffset> {
+        P::find_pvar_index(self, free_var)
     }
 
-    fn on_bound(&self, state: ScopeState, name: BoundVar) -> Option<FreeVar<Ident>> {
-        P::on_bound(self, state, name)
+    fn find_pvar_at_offset(&self, offset: PVarOffset) -> Result<PVar<Ident>, PVarOffset> {
+        P::find_pvar_at_offset(self, offset)
     }
 }
 
@@ -824,11 +811,11 @@ where
         P::pattern_eq(self, other)
     }
 
-    fn freshen(&mut self, permutations: &mut PatternSubsts<FreeVar<Ident>>) {
+    fn freshen(&mut self, permutations: &mut Permutations<Ident>) {
         P::freshen(Arc::make_mut(self), permutations)
     }
 
-    fn swaps(&mut self, permutations: &PatternSubsts<FreeVar<Ident>>) {
+    fn swaps(&mut self, permutations: &Permutations<Ident>) {
         P::swaps(Arc::make_mut(self), permutations);
     }
 
@@ -840,12 +827,12 @@ where
         P::open_pattern(Arc::make_mut(self), state, pattern);
     }
 
-    fn on_free(&self, state: ScopeState, name: &FreeVar<Ident>) -> Option<BoundVar> {
-        P::on_free(self, state, name)
+    fn find_pvar_index(&self, free_var: &FreeVar<Ident>) -> Result<PVarIndex, PVarOffset> {
+        P::find_pvar_index(self, free_var)
     }
 
-    fn on_bound(&self, state: ScopeState, name: BoundVar) -> Option<FreeVar<Ident>> {
-        P::on_bound(self, state, name)
+    fn find_pvar_at_offset(&self, offset: PVarOffset) -> Result<PVar<Ident>, PVarOffset> {
+        P::find_pvar_at_offset(self, offset)
     }
 }
 
@@ -859,17 +846,15 @@ where
             && <_>::zip(self.iter(), other.iter()).all(|(lhs, rhs)| P::pattern_eq(lhs, rhs))
     }
 
-    fn freshen(&mut self, permutations: &mut PatternSubsts<FreeVar<Ident>>) {
+    fn freshen(&mut self, permutations: &mut Permutations<Ident>) {
         for elem in self {
             elem.freshen(permutations);
         }
     }
 
-    fn swaps(&mut self, permutations: &PatternSubsts<FreeVar<Ident>>) {
-        assert_eq!(self.len(), permutations.len()); // FIXME: assertion
-
-        for (pattern, free_var) in <_>::zip(self.iter_mut(), permutations.iter()) {
-            pattern.swaps(&PatternSubsts::new(vec![free_var.clone()])); // FIXME: clone
+    fn swaps(&mut self, permutations: &Permutations<Ident>) {
+        for elem in self {
+            elem.swaps(permutations);
         }
     }
 
@@ -885,31 +870,25 @@ where
         }
     }
 
-    fn on_free(&self, state: ScopeState, name: &FreeVar<Ident>) -> Option<BoundVar> {
-        self.iter()
-            .enumerate()
-            .filter_map(|(i, pattern)| {
-                pattern.on_free(state, name).map(|bound| {
-                    assert_eq!(bound.pattern, PatternIndex(0));
-                    BoundVar {
-                        pattern: PatternIndex(i as u32),
-                        ..bound
-                    }
-                })
-            })
-            .next()
+    fn find_pvar_index(&self, free_var: &FreeVar<Ident>) -> Result<PVarIndex, PVarOffset> {
+        let mut skipped = PVarOffset(0);
+        for elem in self {
+            match elem.find_pvar_index(free_var) {
+                Ok(pvar_index) => return Ok(pvar_index + skipped),
+                Err(next_skipped) => skipped += next_skipped,
+            }
+        }
+        Err(skipped)
     }
 
-    fn on_bound(&self, state: ScopeState, name: BoundVar) -> Option<FreeVar<Ident>> {
-        self.get(name.pattern.0 as usize).and_then(|pattern| {
-            pattern.on_bound(
-                state,
-                BoundVar {
-                    pattern: PatternIndex(0),
-                    ..name
-                },
-            )
-        })
+    fn find_pvar_at_offset(&self, mut offset: PVarOffset) -> Result<PVar<Ident>, PVarOffset> {
+        for elem in self {
+            match elem.find_pvar_at_offset(offset) {
+                Ok(pvar) => return Ok(pvar),
+                Err(next_offset) => offset = next_offset,
+            }
+        }
+        Err(offset)
     }
 }
 
@@ -922,12 +901,12 @@ where
         <[P]>::pattern_eq(self, other)
     }
 
-    fn freshen(&mut self, permutations: &mut PatternSubsts<FreeVar<Ident>>) {
-        <[P]>::freshen(self, permutations)
+    fn freshen(&mut self, permutations: &mut Permutations<Ident>) {
+        <[P]>::freshen(self, permutations);
     }
 
-    fn swaps(&mut self, permutations: &PatternSubsts<FreeVar<Ident>>) {
-        <[P]>::swaps(self, permutations);
+    fn swaps(&mut self, permutations: &Permutations<Ident>) {
+        <[P]>::swaps(self, permutations)
     }
 
     fn close_pattern(&mut self, state: ScopeState, pattern: &impl BoundPattern<Ident>) {
@@ -938,11 +917,294 @@ where
         <[P]>::open_pattern(self, state, pattern);
     }
 
-    fn on_free(&self, state: ScopeState, name: &FreeVar<Ident>) -> Option<BoundVar> {
-        <[P]>::on_free(self, state, name)
+    fn find_pvar_index(&self, free_var: &FreeVar<Ident>) -> Result<PVarIndex, PVarOffset> {
+        <[P]>::find_pvar_index(self, free_var)
     }
 
-    fn on_bound(&self, state: ScopeState, name: BoundVar) -> Option<FreeVar<Ident>> {
-        <[P]>::on_bound(self, state, name)
+    fn find_pvar_at_offset(&self, offset: PVarOffset) -> Result<PVar<Ident>, PVarOffset> {
+        <[P]>::find_pvar_at_offset(self, offset)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn pvar(ident: &str) -> PVar<&str> {
+        PVar::user(ident)
+    }
+
+    fn free_var(ident: &str) -> FreeVar<&str> {
+        FreeVar::user(ident)
+    }
+
+    mod pvar {
+        use super::*;
+
+        mod find_pvar_index {
+            use super::*;
+
+            #[test]
+            fn test_not_found() {
+                assert_eq!(
+                    pvar("a").find_pvar_index(&free_var("b")),
+                    Err(PVarOffset(1)),
+                );
+            }
+
+            #[test]
+            fn test_found() {
+                assert_eq!(
+                    pvar("a").find_pvar_index(&free_var("a")),
+                    Ok(PVarIndex(PVarOffset(0))),
+                );
+            }
+        }
+
+        mod find_pvar_at_offset {
+            use super::*;
+
+            #[test]
+            fn test_not_found() {
+                assert_eq!(
+                    pvar("a").find_pvar_at_offset(PVarOffset(2)),
+                    Err(PVarOffset(1)),
+                );
+            }
+
+            #[test]
+            fn test_found() {
+                assert_eq!(pvar("a").find_pvar_at_offset(PVarOffset(0)), Ok(pvar("a")),);
+            }
+        }
+    }
+
+    mod unit {
+        use super::*;
+
+        mod find_pvar_index {
+            use super::*;
+
+            #[test]
+            fn test_not_found() {
+                assert_eq!(().find_pvar_index(&free_var("a")), Err(PVarOffset(0)));
+            }
+        }
+
+        mod find_pvar_at_offset {
+            use super::*;
+
+            #[test]
+            fn test_not_found() {
+                assert_eq!(
+                    BoundPattern::<&str>::find_pvar_at_offset(&(), PVarOffset(2)),
+                    Err(PVarOffset(2))
+                );
+            }
+        }
+    }
+
+    mod opt {
+        use super::*;
+
+        mod find_pvar_index {
+            use super::*;
+
+            #[test]
+            fn test_none_not_found() {
+                assert_eq!(
+                    None::<()>.find_pvar_index(&free_var("a")),
+                    Err(PVarOffset(0)),
+                );
+            }
+
+            #[test]
+            fn test_some_not_found() {
+                assert_eq!(
+                    Some(pvar("a")).find_pvar_index(&free_var("b")),
+                    Err(PVarOffset(1)),
+                );
+            }
+
+            #[test]
+            fn test_some_found() {
+                assert_eq!(
+                    Some(pvar("a")).find_pvar_index(&free_var("a")),
+                    Ok(PVarIndex(PVarOffset(0))),
+                );
+            }
+        }
+
+        mod find_pvar_at_offset {
+            use super::*;
+
+            #[test]
+            fn test_none_not_found() {
+                assert_eq!(
+                    BoundPattern::<&str>::find_pvar_at_offset(&None::<()>, PVarOffset(2)),
+                    Err(PVarOffset(2))
+                );
+            }
+
+            #[test]
+            fn test_some_not_found() {
+                assert_eq!(
+                    Some(pvar("a")).find_pvar_at_offset(PVarOffset(2)),
+                    Err(PVarOffset(1))
+                );
+            }
+
+            #[test]
+            fn test_some_found() {
+                assert_eq!(
+                    Some(pvar("a")).find_pvar_at_offset(PVarOffset(0)),
+                    Ok(pvar("a"))
+                );
+            }
+        }
+    }
+
+    mod pair {
+        use super::*;
+
+        mod find_pvar_index {
+            use super::*;
+
+            #[test]
+            fn test_0_found() {
+                assert_eq!(
+                    (pvar("a"), pvar("b")).find_pvar_index(&free_var("a")),
+                    Ok(PVarIndex(PVarOffset(0))),
+                );
+            }
+
+            #[test]
+            fn test_1_found() {
+                assert_eq!(
+                    (pvar("a"), pvar("b")).find_pvar_index(&free_var("b")),
+                    Ok(PVarIndex(PVarOffset(1))),
+                );
+            }
+
+            #[test]
+            fn test_opt_1_found() {
+                assert_eq!(
+                    ((), Some(pvar("b"))).find_pvar_index(&free_var("b")),
+                    Ok(PVarIndex(PVarOffset(0))),
+                );
+            }
+        }
+
+        mod find_pvar_at_offset {
+            use super::*;
+
+            #[test]
+            fn test_not_found() {
+                assert_eq!(
+                    (pvar("a"), pvar("b")).find_pvar_at_offset(PVarOffset(2)),
+                    Err(PVarOffset(0))
+                );
+            }
+
+            #[test]
+            fn test_found() {
+                assert_eq!(
+                    (pvar("a"), pvar("b")).find_pvar_at_offset(PVarOffset(1)),
+                    Ok(pvar("b"))
+                );
+            }
+        }
+    }
+
+    mod vec {
+        use super::*;
+
+        mod find_pvar_index {
+            use super::*;
+
+            #[test]
+            fn test_0_found() {
+                assert_eq!(
+                    vec![pvar("a"), pvar("b"), pvar("c")].find_pvar_index(&free_var("a")),
+                    Ok(PVarIndex(PVarOffset(0))),
+                );
+            }
+
+            #[test]
+            fn test_1_found() {
+                assert_eq!(
+                    vec![pvar("a"), pvar("b"), pvar("c")].find_pvar_index(&free_var("b")),
+                    Ok(PVarIndex(PVarOffset(1))),
+                );
+            }
+
+            #[test]
+            fn test_2_found() {
+                assert_eq!(
+                    vec![pvar("a"), pvar("b"), pvar("c")].find_pvar_index(&free_var("c")),
+                    Ok(PVarIndex(PVarOffset(2))),
+                );
+            }
+
+            #[test]
+            fn test_not_found() {
+                assert_eq!(
+                    vec![pvar("a"), pvar("b"), pvar("c")].find_pvar_index(&free_var("d")),
+                    Err(PVarOffset(3)),
+                );
+            }
+
+            #[test]
+            fn test_opt_1_found() {
+                assert_eq!(
+                    vec![None, Some(pvar("b")), Some(pvar("c"))].find_pvar_index(&free_var("b")),
+                    Ok(PVarIndex(PVarOffset(0))),
+                );
+            }
+
+            #[test]
+            fn test_opt_2_found() {
+                assert_eq!(
+                    vec![None, Some(pvar("b")), Some(pvar("c"))].find_pvar_index(&free_var("c")),
+                    Ok(PVarIndex(PVarOffset(1))),
+                );
+            }
+        }
+
+        mod find_pvar_at_offset {
+            use super::*;
+
+            #[test]
+            fn test_not_found() {
+                assert_eq!(
+                    vec![pvar("a"), pvar("b"), pvar("c")].find_pvar_at_offset(PVarOffset(4)),
+                    Err(PVarOffset(1))
+                );
+            }
+
+            #[test]
+            fn test_found() {
+                assert_eq!(
+                    vec![pvar("a"), pvar("b"), pvar("c")].find_pvar_at_offset(PVarOffset(1)),
+                    Ok(pvar("b"))
+                );
+            }
+
+            #[test]
+            fn test_opt_not_found() {
+                assert_eq!(
+                    vec![Some(pvar("a")), None, Some(pvar("c"))].find_pvar_at_offset(PVarOffset(2)),
+                    Err(PVarOffset(0))
+                );
+            }
+
+            #[test]
+            fn test_opt_found() {
+                assert_eq!(
+                    vec![Some(pvar("a")), None, Some(pvar("c"))].find_pvar_at_offset(PVarOffset(1)),
+                    Ok(pvar("c"))
+                );
+            }
+        }
     }
 }

--- a/moniker/src/embed.rs
+++ b/moniker/src/embed.rs
@@ -1,5 +1,5 @@
-use bound::{BoundPattern, BoundTerm, PatternSubsts, ScopeState};
-use var::{BoundVar, FreeVar};
+use bound::{BoundPattern, BoundTerm, Permutations, ScopeState};
+use var::{FreeVar, PVar, PVarIndex, PVarOffset};
 
 /// Embed a term in a pattern
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -13,9 +13,9 @@ where
         T::term_eq(&self.0, &other.0)
     }
 
-    fn freshen(&mut self, _: &mut PatternSubsts<FreeVar<Ident>>) {}
+    fn freshen(&mut self, _: &mut Permutations<Ident>) {}
 
-    fn swaps(&mut self, _: &PatternSubsts<FreeVar<Ident>>) {}
+    fn swaps(&mut self, _: &Permutations<Ident>) {}
 
     fn close_pattern(&mut self, state: ScopeState, pattern: &impl BoundPattern<Ident>) {
         self.0.close_term(state, pattern);
@@ -25,11 +25,11 @@ where
         self.0.open_term(state, pattern);
     }
 
-    fn on_free(&self, _: ScopeState, _: &FreeVar<Ident>) -> Option<BoundVar> {
-        None
+    fn find_pvar_index(&self, _: &FreeVar<Ident>) -> Result<PVarIndex, PVarOffset> {
+        Err(PVarOffset(0))
     }
 
-    fn on_bound(&self, _: ScopeState, _: BoundVar) -> Option<FreeVar<Ident>> {
-        None
+    fn find_pvar_at_offset(&self, offset: PVarOffset) -> Result<PVar<Ident>, PVarOffset> {
+        Err(offset)
     }
 }

--- a/moniker/src/embed.rs
+++ b/moniker/src/embed.rs
@@ -13,9 +13,7 @@ where
         T::term_eq(&self.0, &other.0)
     }
 
-    fn freshen(&mut self) -> PatternSubsts<FreeVar<Ident>> {
-        PatternSubsts::new(Vec::new())
-    }
+    fn freshen(&mut self, _: &mut PatternSubsts<FreeVar<Ident>>) {}
 
     fn swaps(&mut self, _: &PatternSubsts<FreeVar<Ident>>) {}
 

--- a/moniker/src/embed.rs
+++ b/moniker/src/embed.rs
@@ -17,7 +17,7 @@ where
         PatternSubsts::new(Vec::new())
     }
 
-    fn rename(&mut self, _perm: &PatternSubsts<FreeVar<Ident>>) {}
+    fn swaps(&mut self, _: &PatternSubsts<FreeVar<Ident>>) {}
 
     fn close_pattern(&mut self, state: ScopeState, pattern: &impl BoundPattern<Ident>) {
         self.0.close_term(state, pattern);
@@ -27,11 +27,11 @@ where
         self.0.open_term(state, pattern);
     }
 
-    fn on_free(&self, _state: ScopeState, _name: &FreeVar<Ident>) -> Option<BoundVar> {
+    fn on_free(&self, _: ScopeState, _: &FreeVar<Ident>) -> Option<BoundVar> {
         None
     }
 
-    fn on_bound(&self, _state: ScopeState, _name: BoundVar) -> Option<FreeVar<Ident>> {
+    fn on_bound(&self, _: ScopeState, _: BoundVar) -> Option<FreeVar<Ident>> {
         None
     }
 }

--- a/moniker/src/ignore.rs
+++ b/moniker/src/ignore.rs
@@ -1,5 +1,5 @@
-use bound::{BoundPattern, BoundTerm, PatternSubsts, ScopeState};
-use var::{BoundVar, FreeVar, Var};
+use bound::{BoundPattern, BoundTerm, Permutations, ScopeState};
+use var::{FreeVar, PVar, PVarIndex, PVarOffset, TVar};
 
 /// Data that does not participate in name binding
 ///
@@ -17,9 +17,9 @@ impl<Ident, T> BoundTerm<Ident> for Ignore<T> {
 
     fn open_term(&mut self, _: ScopeState, _: &impl BoundPattern<Ident>) {}
 
-    fn visit_vars(&self, _: &mut impl FnMut(&Var<Ident>)) {}
+    fn visit_vars(&self, _: &mut impl FnMut(&TVar<Ident>)) {}
 
-    fn visit_mut_vars(&mut self, _: &mut impl FnMut(&mut Var<Ident>)) {}
+    fn visit_mut_vars(&mut self, _: &mut impl FnMut(&mut TVar<Ident>)) {}
 }
 
 impl<Ident, T> BoundPattern<Ident> for Ignore<T> {
@@ -27,19 +27,19 @@ impl<Ident, T> BoundPattern<Ident> for Ignore<T> {
         true
     }
 
-    fn freshen(&mut self, _: &mut PatternSubsts<FreeVar<Ident>>) {}
+    fn freshen(&mut self, _: &mut Permutations<Ident>) {}
 
-    fn swaps(&mut self, _: &PatternSubsts<FreeVar<Ident>>) {}
+    fn swaps(&mut self, _: &Permutations<Ident>) {}
 
     fn close_pattern(&mut self, _: ScopeState, _: &impl BoundPattern<Ident>) {}
 
     fn open_pattern(&mut self, _: ScopeState, _: &impl BoundPattern<Ident>) {}
 
-    fn on_free(&self, _: ScopeState, _: &FreeVar<Ident>) -> Option<BoundVar> {
-        None
+    fn find_pvar_index(&self, _: &FreeVar<Ident>) -> Result<PVarIndex, PVarOffset> {
+        Err(PVarOffset(0))
     }
 
-    fn on_bound(&self, _: ScopeState, _: BoundVar) -> Option<FreeVar<Ident>> {
-        None
+    fn find_pvar_at_offset(&self, offset: PVarOffset) -> Result<PVar<Ident>, PVarOffset> {
+        Err(offset)
     }
 }

--- a/moniker/src/ignore.rs
+++ b/moniker/src/ignore.rs
@@ -27,9 +27,7 @@ impl<Ident, T> BoundPattern<Ident> for Ignore<T> {
         true
     }
 
-    fn freshen(&mut self) -> PatternSubsts<FreeVar<Ident>> {
-        PatternSubsts::new(Vec::new())
-    }
+    fn freshen(&mut self, _: &mut PatternSubsts<FreeVar<Ident>>) {}
 
     fn swaps(&mut self, _: &PatternSubsts<FreeVar<Ident>>) {}
 

--- a/moniker/src/ignore.rs
+++ b/moniker/src/ignore.rs
@@ -31,7 +31,7 @@ impl<Ident, T> BoundPattern<Ident> for Ignore<T> {
         PatternSubsts::new(Vec::new())
     }
 
-    fn rename(&mut self, _: &PatternSubsts<FreeVar<Ident>>) {}
+    fn swaps(&mut self, _: &PatternSubsts<FreeVar<Ident>>) {}
 
     fn close_pattern(&mut self, _: ScopeState, _: &impl BoundPattern<Ident>) {}
 

--- a/moniker/src/lib.rs
+++ b/moniker/src/lib.rs
@@ -11,7 +11,7 @@
 //! extern crate moniker;
 //!
 //! use std::rc::Rc;
-//! use moniker::{Embed, FreeVar, Nest, Scope, Var};
+//! use moniker::{Embed, Nest, PVar, Scope, TVar};
 //!
 //! # #[cfg(feature = "moniker-derive")]
 //! #[derive(Debug, Clone, BoundTerm)]
@@ -23,9 +23,9 @@
 //! # #[cfg(feature = "moniker-derive")]
 //! #[derive(Debug, Clone, BoundTerm)]
 //! pub enum Expr {
-//!     Var(Var<String>),
-//!     Lam(Scope<(FreeVar<String>, Embed<Rc<Type>>), Rc<Expr>>),
-//!     Let(Scope<Nest<(FreeVar<String>, Embed<(Rc<Type>, Rc<Expr>)>)>, Rc<Expr>>),
+//!     Var(TVar<String>),
+//!     Lam(Scope<(PVar<String>, Embed<Rc<Type>>), Rc<Expr>>),
+//!     Let(Scope<Nest<(PVar<String>, Embed<(Rc<Type>, Rc<Expr>)>)>, Rc<Expr>>),
 //!     App(Rc<Expr>, Rc<Expr>),
 //! }
 //! # fn main() {}
@@ -39,21 +39,30 @@
 //!
 //! ## Terms
 //!
-//! Terms are data types that implement the `BoundTerm` trait.
+//! Terms are data types that implement the [`BoundTerm`] trait.
 //!
-//! - `Var<Ident>`: A variable that is either a `FreeVar<Ident>` or `BoundVar`
-//! - `Scope<P: BoundPattern<Ident>, T: BoundTerm<Ident>>`: bind the term `T` using the pattern `P`
+//! - [`TVar<Ident>`]: A variable that is either free or bound
+//! - [`Scope<P: BoundPattern<Ident>, T: BoundTerm<Ident>>`]: bind the term `T` using the pattern `P`
 //!
 //! ## Patterns
 //!
-//! Patterns are data types that implement the `BoundPattern` trait.
+//! Patterns are data types that implement the [`BoundPattern`] trait.
 //!
-//! - `FreeVar<Ident>`: Captures a free variable within a term, but is ignored for alpha equality
-//! - `Ignore<T>`: Ignores `T` when comparing for alpha equality
-//! - `Embed<T: BoundTerm<Ident>>`: Embed a term in a pattern
-//! - `Multi<T: BoundPattern<Ident>>`: Multiple parallel binding patterns
-//! - `Nest<T: BoundPattern<Ident>>`: Multiple nested binding patterns
-//! - `Rec<T: BoundPattern<Ident>>`: Recursive binding patterns
+//! - [`PVar<Ident>`]: Captures a free variables within a term, but is ignored for alpha equality
+//! - [`Ignore<T>`]: Ignores `T` when comparing for alpha equality
+//! - [`Embed<T: BoundTerm<Ident>>`]: Embed a term `T` in a pattern
+//! - [`Nest<P: BoundPattern<Ident>>`]: Multiple nested binding patterns
+//! - [`Rec<P: BoundPattern<Ident>>`]: Recursively bind a pattern in itself
+//!
+//! [`TVar<Ident>`]: enum.TVar.html
+//! [`Scope<P: BoundPattern<Ident>, T: BoundTerm<Ident>>`]: struct.Scope.html
+//! [`PVar<Ident>`]: enum.PVar.html
+//! [`Ignore<T>`]: struct.Ignore.html
+//! [`Embed<T: BoundTerm<Ident>>`]: struct.Embed.html
+//! [`Nest<P: BoundPattern<Ident>>`]: struct.Nest.html
+//! [`Rec<P: BoundPattern<Ident>>`]: struct.Rec.html
+//! [`BoundTerm`]: trait.BoundTerm.html
+//! [`BoundPattern`]: trait.BoundPattern.html
 
 #[cfg(feature = "codespan")]
 extern crate codespan;
@@ -80,10 +89,10 @@ mod rec;
 mod scope;
 mod var;
 
-pub use self::bound::{BoundPattern, BoundTerm, PatternSubsts, ScopeState};
+pub use self::bound::{BoundPattern, BoundTerm, Permutations, ScopeState};
 pub use self::embed::Embed;
 pub use self::ignore::Ignore;
 pub use self::nest::Nest;
 pub use self::rec::Rec;
 pub use self::scope::Scope;
-pub use self::var::{BoundVar, FreeVar, GenId, PatternIndex, ScopeOffset, Var};
+pub use self::var::{FreeVar, GenId, PVar, PVarIndex, PVarOffset, ScopeOffset, TVar};

--- a/moniker/src/lib.rs
+++ b/moniker/src/lib.rs
@@ -69,6 +69,9 @@ extern crate moniker_derive;
 pub use moniker_derive::*;
 
 #[macro_use]
+#[doc(hidden)]
+pub mod macros;
+
 mod bound;
 mod embed;
 mod ignore;

--- a/moniker/src/macros.rs
+++ b/moniker/src/macros.rs
@@ -1,0 +1,77 @@
+//! Macros for use with the Moniker library
+
+/// Assert that two expressions are alpha equivalent to each other (using
+/// `BoundTerm::term_eq`).
+///
+/// On panic, this macro will print the values of the expressions with their
+/// debug representations.
+///
+/// Like `assert!`, this macro has a second form, where a custom
+/// panic message can be provided.
+#[macro_export]
+macro_rules! assert_term_eq {
+    ($left:expr, $right:expr) => ({
+        match (&$left, &$right) {
+            (left_val, right_val) => {
+                if !::moniker::BoundTerm::term_eq(left_val, right_val) {
+                    panic!(r#"assertion failed: `<_>::term_eq(&left, &right)`
+  left: `{:?}`,
+ right: `{:?}`"#, left_val, right_val)
+                }
+            }
+        }
+    });
+    ($left:expr, $right:expr,) => ({
+        assert_term_eq!($left, $right)
+    });
+    ($left:expr, $right:expr, $($arg:tt)+) => ({
+        match (&($left), &($right)) {
+            (left_val, right_val) => {
+                if !::moniker::BoundTerm::term_eq(left_val, right_val) {
+                    panic!(r#"assertion failed: `<_>::term_eq(&left, &right)`
+  left: `{:?}`,
+ right: `{:?}`: {}"#, left_val, right_val,
+                           format_args!($($arg)+))
+                }
+            }
+        }
+    });
+}
+
+/// Assert that two expressions are alpha equivalent to each other (using
+/// `BoundPattern::pattern_eq`).
+///
+/// On panic, this macro will print the values of the expressions with their
+/// debug representations.
+///
+/// Like `assert!`, this macro has a second form, where a custom
+/// panic message can be provided.
+#[macro_export]
+macro_rules! assert_pattern_eq {
+    ($left:expr, $right:expr) => ({
+        match (&$left, &$right) {
+            (left_val, right_val) => {
+                if !::moniker::BoundPattern::pattern_eq(left_val, right_val) {
+                    panic!(r#"assertion failed: `<_>::pattern_eq(&left, &right)`
+  left: `{:?}`,
+ right: `{:?}`"#, left_val, right_val)
+                }
+            }
+        }
+    });
+    ($left:expr, $right:expr,) => ({
+        assert_pattern_eq!($left, $right)
+    });
+    ($left:expr, $right:expr, $($arg:tt)+) => ({
+        match (&($left), &($right)) {
+            (left_val, right_val) => {
+                if !::moniker::BoundPattern::pattern_eq(left_val, right_val) {
+                    panic!(r#"assertion failed: `<_>::pattern_eq(&left, &right)`
+  left: `{:?}`,
+ right: `{:?}`: {}"#, left_val, right_val,
+                           format_args!($($arg)+))
+                }
+            }
+        }
+    });
+}

--- a/moniker/src/nest.rs
+++ b/moniker/src/nest.rs
@@ -66,8 +66,8 @@ where
         <[P]>::freshen(&mut self.unsafe_patterns)
     }
 
-    fn rename(&mut self, perm: &PatternSubsts<FreeVar<Ident>>) {
-        <[P]>::rename(&mut self.unsafe_patterns, perm)
+    fn swaps(&mut self, permutations: &PatternSubsts<FreeVar<Ident>>) {
+        <[P]>::swaps(&mut self.unsafe_patterns, permutations)
     }
 
     fn close_pattern(&mut self, mut state: ScopeState, pattern: &impl BoundPattern<Ident>) {

--- a/moniker/src/nest.rs
+++ b/moniker/src/nest.rs
@@ -62,8 +62,8 @@ where
         <[P]>::pattern_eq(&self.unsafe_patterns, &other.unsafe_patterns)
     }
 
-    fn freshen(&mut self) -> PatternSubsts<FreeVar<Ident>> {
-        <[P]>::freshen(&mut self.unsafe_patterns)
+    fn freshen(&mut self, permutations: &mut PatternSubsts<FreeVar<Ident>>) {
+        <[P]>::freshen(&mut self.unsafe_patterns, permutations)
     }
 
     fn swaps(&mut self, permutations: &PatternSubsts<FreeVar<Ident>>) {

--- a/moniker/src/nest.rs
+++ b/moniker/src/nest.rs
@@ -1,5 +1,5 @@
-use bound::{BoundPattern, PatternSubsts, ScopeState};
-use var::{BoundVar, FreeVar};
+use bound::{BoundPattern, Permutations, ScopeState};
+use var::{FreeVar, PVar, PVarIndex, PVarOffset};
 
 /// Nested binding patterns
 ///
@@ -62,11 +62,11 @@ where
         <[P]>::pattern_eq(&self.unsafe_patterns, &other.unsafe_patterns)
     }
 
-    fn freshen(&mut self, permutations: &mut PatternSubsts<FreeVar<Ident>>) {
+    fn freshen(&mut self, permutations: &mut Permutations<Ident>) {
         <[P]>::freshen(&mut self.unsafe_patterns, permutations)
     }
 
-    fn swaps(&mut self, permutations: &PatternSubsts<FreeVar<Ident>>) {
+    fn swaps(&mut self, permutations: &Permutations<Ident>) {
         <[P]>::swaps(&mut self.unsafe_patterns, permutations)
     }
 
@@ -84,11 +84,11 @@ where
         }
     }
 
-    fn on_free(&self, state: ScopeState, name: &FreeVar<Ident>) -> Option<BoundVar> {
-        <[P]>::on_free(&self.unsafe_patterns, state, name)
+    fn find_pvar_index(&self, free_var: &FreeVar<Ident>) -> Result<PVarIndex, PVarOffset> {
+        <[P]>::find_pvar_index(&self.unsafe_patterns, free_var)
     }
 
-    fn on_bound(&self, state: ScopeState, name: BoundVar) -> Option<FreeVar<Ident>> {
-        <[P]>::on_bound(&self.unsafe_patterns, state, name)
+    fn find_pvar_at_offset(&self, offset: PVarOffset) -> Result<PVar<Ident>, PVarOffset> {
+        <[P]>::find_pvar_at_offset(&self.unsafe_patterns, offset)
     }
 }

--- a/moniker/src/rec.rs
+++ b/moniker/src/rec.rs
@@ -39,8 +39,8 @@ where
         self.unsafe_pattern.freshen()
     }
 
-    fn rename(&mut self, perm: &PatternSubsts<FreeVar<Ident>>) {
-        self.unsafe_pattern.rename(perm)
+    fn swaps(&mut self, permutations: &PatternSubsts<FreeVar<Ident>>) {
+        self.unsafe_pattern.swaps(permutations)
     }
 
     fn close_pattern(&mut self, state: ScopeState, pattern: &impl BoundPattern<Ident>) {

--- a/moniker/src/rec.rs
+++ b/moniker/src/rec.rs
@@ -1,7 +1,10 @@
-use bound::{BoundPattern, PatternSubsts, ScopeState};
-use var::{BoundVar, FreeVar};
+use bound::{BoundPattern, Permutations, ScopeState};
+use var::{FreeVar, PVar, PVarIndex, PVarOffset};
 
-/// Recursive patterns
+/// Recursively bind a pattern in itself
+///
+/// Mutually recursive bindings can be modelled by combining this type with
+/// the pattern implementations for `Vec<P>` and `(P1, P2)`.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct Rec<P> {
     pub unsafe_pattern: P,
@@ -35,11 +38,11 @@ where
         P::pattern_eq(&self.unsafe_pattern, &other.unsafe_pattern)
     }
 
-    fn freshen(&mut self, permutations: &mut PatternSubsts<FreeVar<Ident>>) {
+    fn freshen(&mut self, permutations: &mut Permutations<Ident>) {
         self.unsafe_pattern.freshen(permutations)
     }
 
-    fn swaps(&mut self, permutations: &PatternSubsts<FreeVar<Ident>>) {
+    fn swaps(&mut self, permutations: &Permutations<Ident>) {
         self.unsafe_pattern.swaps(permutations)
     }
 
@@ -51,11 +54,11 @@ where
         self.unsafe_pattern.open_pattern(state, pattern);
     }
 
-    fn on_free(&self, state: ScopeState, name: &FreeVar<Ident>) -> Option<BoundVar> {
-        self.unsafe_pattern.on_free(state, name)
+    fn find_pvar_index(&self, free_var: &FreeVar<Ident>) -> Result<PVarIndex, PVarOffset> {
+        self.unsafe_pattern.find_pvar_index(free_var)
     }
 
-    fn on_bound(&self, state: ScopeState, name: BoundVar) -> Option<FreeVar<Ident>> {
-        self.unsafe_pattern.on_bound(state, name)
+    fn find_pvar_at_offset(&self, offset: PVarOffset) -> Result<PVar<Ident>, PVarOffset> {
+        self.unsafe_pattern.find_pvar_at_offset(offset)
     }
 }

--- a/moniker/src/rec.rs
+++ b/moniker/src/rec.rs
@@ -35,8 +35,8 @@ where
         P::pattern_eq(&self.unsafe_pattern, &other.unsafe_pattern)
     }
 
-    fn freshen(&mut self) -> PatternSubsts<FreeVar<Ident>> {
-        self.unsafe_pattern.freshen()
+    fn freshen(&mut self, permutations: &mut PatternSubsts<FreeVar<Ident>>) {
+        self.unsafe_pattern.freshen(permutations)
     }
 
     fn swaps(&mut self, permutations: &PatternSubsts<FreeVar<Ident>>) {

--- a/moniker/src/scope.rs
+++ b/moniker/src/scope.rs
@@ -1,4 +1,4 @@
-use bound::{BoundPattern, BoundTerm, ScopeState};
+use bound::{BoundPattern, BoundTerm, PatternSubsts, ScopeState};
 use var::Var;
 
 /// A bound scope
@@ -37,10 +37,11 @@ impl<P, T> Scope<P, T> {
         P: BoundPattern<Ident>,
         T: BoundTerm<Ident>,
     {
+        let mut permutations = PatternSubsts::new(vec![]);
         let mut pattern = self.unsafe_pattern;
         let mut body = self.unsafe_body;
 
-        pattern.freshen();
+        pattern.freshen(&mut permutations);
         body.open_term(ScopeState::new(), &pattern);
 
         (pattern, body)
@@ -62,8 +63,9 @@ impl<P, T> Scope<P, T> {
         let mut other_body = other.unsafe_body;
 
         {
-            let names = self_pattern.freshen();
-            other_pattern.swaps(&names);
+            let mut permutations = PatternSubsts::new(vec![]);
+            self_pattern.freshen(&mut permutations);
+            other_pattern.swaps(&permutations);
             self_body.open_term(ScopeState::new(), &self_pattern);
             other_body.open_term(ScopeState::new(), &other_pattern);
         }

--- a/moniker/src/scope.rs
+++ b/moniker/src/scope.rs
@@ -63,7 +63,7 @@ impl<P, T> Scope<P, T> {
 
         {
             let names = self_pattern.freshen();
-            other_pattern.rename(&names);
+            other_pattern.swaps(&names);
             self_body.open_term(ScopeState::new(), &self_pattern);
             other_body.open_term(ScopeState::new(), &other_pattern);
         }

--- a/moniker/src/var.rs
+++ b/moniker/src/var.rs
@@ -1,6 +1,7 @@
 use std::fmt;
 use std::hash::{Hash, Hasher};
 use std::mem;
+use std::ops;
 
 /// A generated id
 #[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
@@ -40,6 +41,13 @@ impl<Ident> FreeVar<Ident> {
     /// Create a name from a human-readable string
     pub fn user<T: Into<Ident>>(ident: T) -> FreeVar<Ident> {
         FreeVar::User(ident.into())
+    }
+
+    pub fn fresh(self) -> FreeVar<Ident> {
+        match self {
+            FreeVar::User(name) => FreeVar::Gen(GenId::fresh(), Some(name)),
+            FreeVar::Gen(_, _) => self,
+        }
     }
 
     pub fn ident(&self) -> Option<&Ident> {
@@ -130,78 +138,266 @@ impl fmt::Display for ScopeOffset {
 }
 
 #[derive(Debug, Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Hash)]
-pub struct PatternIndex(pub u32);
+pub struct PVarOffset(pub u32);
 
-impl fmt::Display for PatternIndex {
+impl PVarOffset {
+    pub fn to_usize(self) -> usize {
+        self.0 as usize
+    }
+}
+
+impl ops::Add for PVarOffset {
+    type Output = PVarOffset;
+
+    fn add(self, other: PVarOffset) -> PVarOffset {
+        PVarOffset(self.0 + other.0)
+    }
+}
+
+impl ops::AddAssign for PVarOffset {
+    fn add_assign(&mut self, other: PVarOffset) {
+        self.0 += other.0;
+    }
+}
+
+impl ops::Sub for PVarOffset {
+    type Output = PVarOffset;
+
+    fn sub(self, other: PVarOffset) -> PVarOffset {
+        PVarOffset(self.0 - other.0)
+    }
+}
+
+impl ops::SubAssign for PVarOffset {
+    fn sub_assign(&mut self, other: PVarOffset) {
+        self.0 -= other.0;
+    }
+}
+
+impl fmt::Display for PVarOffset {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         fmt::Display::fmt(&self.0, f)
     }
 }
 
-/// A bound variable
 #[derive(Debug, Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Hash)]
-pub struct BoundVar {
-    pub scope: ScopeOffset,
-    pub pattern: PatternIndex,
+pub struct PVarIndex(pub PVarOffset);
+
+impl PVarIndex {
+    pub fn to_usize(self) -> usize {
+        self.0.to_usize()
+    }
 }
 
-impl fmt::Display for BoundVar {
+impl ops::Add<PVarOffset> for PVarIndex {
+    type Output = PVarIndex;
+
+    fn add(self, other: PVarOffset) -> PVarIndex {
+        PVarIndex(self.0 + other)
+    }
+}
+
+impl ops::AddAssign<PVarOffset> for PVarIndex {
+    fn add_assign(&mut self, other: PVarOffset) {
+        self.0 += other;
+    }
+}
+
+impl fmt::Display for PVarIndex {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}.{}", self.scope, self.pattern)
+        fmt::Display::fmt(&self.0, f)
     }
 }
 
 /// A variable that can either be free or bound
 #[derive(Debug, Clone)]
-pub enum Var<Ident> {
+pub enum TVar<Ident> {
     /// A free variable
     Free(FreeVar<Ident>),
     /// A variable that is bound by a lambda or pi binder
-    Bound(BoundVar, Option<Ident>),
+    Bound(ScopeOffset, PVarIndex, Option<Ident>),
 }
 
-impl<Ident> Var<Ident> {
-    pub fn user<T: Into<Ident>>(ident: T) -> Var<Ident> {
-        Var::Free(FreeVar::user(ident))
+impl<Ident> TVar<Ident> {
+    /// Create a variable from a human-readable string
+    pub fn user<T: Into<Ident>>(ident: T) -> TVar<Ident> {
+        TVar::Free(FreeVar::user(ident))
+    }
+
+    pub fn try_into_free_var(self) -> Result<FreeVar<Ident>, ()> {
+        match self {
+            TVar::Free(name) => Ok(name),
+            TVar::Bound(_, _, _) => Err(()),
+        }
     }
 }
 
-impl<Ident> PartialEq for Var<Ident>
+impl<Ident> PartialEq for TVar<Ident>
 where
     Ident: PartialEq,
 {
-    fn eq(&self, other: &Var<Ident>) -> bool {
+    fn eq(&self, other: &TVar<Ident>) -> bool {
         match (self, other) {
-            (&Var::Free(ref lhs), &Var::Free(ref rhs)) => lhs == rhs,
-            (&Var::Bound(bound_lhs, _), &Var::Bound(bound_rhs, _)) => bound_lhs == bound_rhs,
+            (&TVar::Free(ref lhs), &TVar::Free(ref rhs)) => lhs == rhs,
+            (
+                &TVar::Bound(scope_offset_lhs, pvar_index_lhs, _),
+                &TVar::Bound(scope_offset_rhs, pvar_index_rhs, _),
+            ) => scope_offset_lhs == scope_offset_rhs && pvar_index_lhs == pvar_index_rhs,
             _ => false,
         }
     }
 }
 
-impl<Ident> Eq for Var<Ident> where Ident: Eq {}
+impl<Ident> Eq for TVar<Ident> where Ident: Eq {}
 
-impl<Ident> Hash for Var<Ident>
+impl<Ident> Hash for TVar<Ident>
 where
     Ident: Hash,
 {
     fn hash<H: Hasher>(&self, state: &mut H) {
         mem::discriminant(self).hash(state);
         match *self {
-            Var::Free(ref name) => name.hash(state),
-            Var::Bound(bound_var, _) => {
-                bound_var.hash(state);
+            TVar::Free(ref name) => name.hash(state),
+            TVar::Bound(scope, pattern, _) => {
+                scope.hash(state);
+                pattern.hash(state);
             },
         }
     }
 }
 
-impl<Ident: fmt::Display> fmt::Display for Var<Ident> {
+impl<Ident: fmt::Display> fmt::Display for TVar<Ident> {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match *self {
-            Var::Bound(bound_var, None) => write!(f, "@{}", bound_var),
-            Var::Bound(bound_var, Some(ref hint)) => write!(f, "{}@{}", hint, bound_var),
-            Var::Free(ref free) => write!(f, "{}", free),
+            TVar::Bound(scope_offset, pvar_index, None) => {
+                write!(f, "@{}.{}", scope_offset, pvar_index)
+            },
+            TVar::Bound(scope_offset, pvar_index, Some(ref hint)) => {
+                write!(f, "{}@{}.{}", hint, scope_offset, pvar_index)
+            },
+            TVar::Free(ref free) => write!(f, "{}", free),
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
+pub enum PVar<Ident> {
+    Free(FreeVar<Ident>),
+    Bound(PVarIndex, Option<Ident>),
+}
+
+impl<Ident> PVar<Ident> {
+    /// Create a variable from a human-readable string
+    pub fn user<T: Into<Ident>>(ident: T) -> PVar<Ident> {
+        PVar::Free(FreeVar::user(ident))
+    }
+
+    pub fn fresh(self) -> PVar<Ident> {
+        match self {
+            PVar::Free(free_var) => PVar::Free(free_var.fresh()),
+            PVar::Bound(_, _) => self,
+        }
+    }
+
+    pub fn to_var(self, scope: ScopeOffset) -> TVar<Ident> {
+        match self {
+            PVar::Free(name) => TVar::Free(name),
+            PVar::Bound(pattern, name) => TVar::Bound(scope, pattern, name),
+        }
+    }
+
+    pub fn try_into_free_var(self) -> Result<FreeVar<Ident>, ()> {
+        match self {
+            PVar::Free(name) => Ok(name),
+            PVar::Bound(_, _) => Err(()),
+        }
+    }
+}
+
+impl<Ident> PartialEq for PVar<Ident>
+where
+    Ident: PartialEq,
+{
+    fn eq(&self, other: &PVar<Ident>) -> bool {
+        match (self, other) {
+            (&PVar::Free(ref lhs), &PVar::Free(ref rhs)) => lhs == rhs,
+            (&PVar::Bound(pvar_index_lhs, _), &PVar::Bound(pvar_index_rhs, _)) => {
+                pvar_index_lhs == pvar_index_rhs
+            },
+            _ => false,
+        }
+    }
+}
+
+impl<Ident> Eq for PVar<Ident> where Ident: Eq {}
+
+impl<Ident> Hash for PVar<Ident>
+where
+    Ident: Hash,
+{
+    fn hash<H: Hasher>(&self, state: &mut H) {
+        mem::discriminant(self).hash(state);
+        match *self {
+            PVar::Free(ref name) => name.hash(state),
+            PVar::Bound(pattern, _) => pattern.hash(state),
+        }
+    }
+}
+
+impl<Ident: fmt::Display> fmt::Display for PVar<Ident> {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match *self {
+            PVar::Bound(pvar_index, None) => write!(f, "@{}", pvar_index),
+            PVar::Bound(pvar_index, Some(ref hint)) => write!(f, "{}@{}", hint, pvar_index),
+            PVar::Free(ref free) => write!(f, "{}", free),
+        }
+    }
+}
+
+impl<Ident> PartialEq<PVar<Ident>> for TVar<Ident>
+where
+    Ident: PartialEq,
+{
+    fn eq(&self, other: &PVar<Ident>) -> bool {
+        match (self, other) {
+            (&TVar::Free(ref lhs), &PVar::Free(ref rhs)) => lhs == rhs,
+            _ => false,
+        }
+    }
+}
+
+impl<Ident> PartialEq<FreeVar<Ident>> for TVar<Ident>
+where
+    Ident: PartialEq,
+{
+    fn eq(&self, other: &FreeVar<Ident>) -> bool {
+        match *self {
+            TVar::Free(ref lhs) => lhs == other,
+            _ => false,
+        }
+    }
+}
+
+impl<Ident> PartialEq<TVar<Ident>> for PVar<Ident>
+where
+    Ident: PartialEq,
+{
+    fn eq(&self, other: &TVar<Ident>) -> bool {
+        match (self, other) {
+            (&PVar::Free(ref lhs), &TVar::Free(ref rhs)) => lhs == rhs,
+            _ => false,
+        }
+    }
+}
+
+impl<Ident> PartialEq<FreeVar<Ident>> for PVar<Ident>
+where
+    Ident: PartialEq,
+{
+    fn eq(&self, other: &FreeVar<Ident>) -> bool {
+        match *self {
+            PVar::Free(ref lhs) => lhs == other,
+            _ => false,
         }
     }
 }


### PR DESCRIPTION
The intention of this PR is to make our pattern indices work for more complex cases. This also allows us to define interesting pattern syntaxes like:

```rust
#[derive(Debug, Clone, PartialEq, BoundTerm, BoundPattern)]
pub enum Literal {
    Int(i32),
    Float(f32),
    String(String),
}

#[derive(Debug, Clone, BoundPattern)]
pub enum Pattern {
    Ann(Rc<Pattern>, Embed<Rc<Type>>),
    Literal(Literal),
    Var(PVar<String>),
    Record(Vec<(String, Rc<Pattern>)>),
    Tag(String, Rc<Pattern>),
}
```

This means that we need to properly assign indices to the patterns (unlike what we currently do, which only works for simple things like `Vec`).

Closes #16.