### PR TITLE
Rename PVar to Binder and TVar to Var

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,20 +82,20 @@ pub type RcPattern = Rc<Pattern>;
 pub enum Expr {
     /// Variables
     Var(TVar<String>),
-    /// Expressions annotated with a type
+    /// Expressions annotated with types
     Ann(RcExpr, RcType),
     /// Anonymous functions (ie. lambda expressions)
     ///
     /// We use the `Scope` type to say that variables in the pattern bind
     /// variables in the body expression
     Lam(Scope<RcPattern, RcExpr>),
-    /// Function application applications
+    /// Function applications
     App(RcExpr, RcExpr),
     /// Mutually recursive let bindings
     ///
     /// We're getting more complex here, combining `Scope` with `Rec`, `Vec`,
-    /// and pairs - check out the examples (under `/moniker/examples` directory)
-    /// to see how we use this!
+    /// and pairs - check out the examples (under the `/moniker/examples`
+    /// directory) to see how we use this in an evaluator or type checker.
     Let(Scope<Rec<Vec<(RcPattern, Embed<RcExpr>)>>, RcExpr>),
 }
 

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ with variables, anonymous functions, applications, and let bindings:
 #[macro_use]
 extern crate moniker;
 
-use moniker::{Embed, PVar, Scope, TVar};
+use moniker::{Embed, Binder, Scope, Var};
 use std::rc::Rc;
 
 /// Types
@@ -59,12 +59,12 @@ pub enum Pattern {
     /// Patterns that bind no variables
     Wildcard,
     /// Patterns that bind variables
-    Var(PVar<String>),
+    Binder(Binder<String>),
     /// Patterns annotated with types
     ///
     /// `Type` does not implement the `BoundPattern` trait, but we can use
     /// `Embed` to embed it patterns.
-    Ann(RcPattern, Embed<Type>),
+    Ann(RcPattern, Embed<RcType>),
 }
 
 pub type RcPattern = Rc<Pattern>;
@@ -81,7 +81,7 @@ pub type RcPattern = Rc<Pattern>;
 #[derive(Debug, Clone, BoundTerm)]
 pub enum Expr {
     /// Variables
-    Var(TVar<String>),
+    Var(Var<String>),
     /// Expressions annotated with types
     Ann(RcExpr, RcType),
     /// Anonymous functions (ie. lambda expressions)

--- a/moniker-derive/src/lib.rs
+++ b/moniker-derive/src/lib.rs
@@ -93,11 +93,11 @@ fn bound_term_derive(mut s: Structure) -> proc_macro2::TokenStream {
                 match *self { #open_term_body }
             }
 
-            fn visit_vars(&self, __on_var: &mut impl FnMut(&moniker::TVar<String>)) {
+            fn visit_vars(&self, __on_var: &mut impl FnMut(&moniker::Var<String>)) {
                 match *self { #visit_vars_body }
             }
 
-            fn visit_mut_vars(&mut self, __on_var: &mut impl FnMut(&mut moniker::TVar<String>)) {
+            fn visit_mut_vars(&mut self, __on_var: &mut impl FnMut(&mut moniker::Var<String>)) {
                 match *self { #visit_mut_vars_body }
             }
         }
@@ -164,18 +164,18 @@ fn bound_pattern_derive(mut s: Structure) -> proc_macro2::TokenStream {
     });
 
     s.bind_with(|_| BindStyle::Ref);
-    let find_pvar_index_body = s.each(|bi| {
+    let find_binder_index_body = s.each(|bi| {
         quote! {
-            match #bi.find_pvar_index(__free_var) {
-                Ok(__pvar_index) => return Ok(__pvar_index + __skipped),
+            match #bi.find_binder_index(__free_var) {
+                Ok(__binder_index) => return Ok(__binder_index + __skipped),
                 Err(__next_skipped) => __skipped += __next_skipped,
             };
         }
     });
-    let find_pvar_at_offset_body = s.each(|bi| {
+    let find_binder_at_offset_body = s.each(|bi| {
         quote! {
-            match #bi.find_pvar_at_offset(__offset) {
-                Ok(__pvar) => return Ok(__pvar),
+            match #bi.find_binder_at_offset(__offset) {
+                Ok(__binder) => return Ok(__binder),
                 Err(__next_offset) => __offset = __next_offset,
             };
         }
@@ -213,20 +213,20 @@ fn bound_pattern_derive(mut s: Structure) -> proc_macro2::TokenStream {
                 match *self { #open_pattern_body }
             }
 
-            fn find_pvar_index(
+            fn find_binder_index(
                 &self,
                 __free_var: &moniker::FreeVar<String>,
-            ) -> Result<moniker::PVarIndex, moniker::PVarOffset> {
-                let mut __skipped = moniker::PVarOffset(0);
-                match *self { #find_pvar_index_body }
+            ) -> Result<moniker::BinderIndex, moniker::BinderOffset> {
+                let mut __skipped = moniker::BinderOffset(0);
+                match *self { #find_binder_index_body }
                 Err(__skipped)
             }
 
-            fn find_pvar_at_offset(
+            fn find_binder_at_offset(
                 &self,
-                mut __offset: moniker::PVarOffset,
-            ) -> Result<moniker::PVar<String>, moniker::PVarOffset> {
-                match *self { #find_pvar_at_offset_body }
+                mut __offset: moniker::BinderOffset,
+            ) -> Result<moniker::Binder<String>, moniker::BinderOffset> {
+                match *self { #find_binder_at_offset_body }
                 Err(__offset)
             }
         }

--- a/moniker/examples/lc.rs
+++ b/moniker/examples/lc.rs
@@ -4,16 +4,16 @@
 #[macro_use]
 extern crate moniker;
 
-use moniker::{PVar, Scope, TVar};
+use moniker::{Binder, Scope, Var};
 use std::rc::Rc;
 
 /// Expressions
 #[derive(Debug, Clone, BoundTerm)]
 pub enum Expr {
     /// Variables
-    Var(TVar<String>),
+    Var(Var<String>),
     /// Lambda expressions
-    Lam(Scope<PVar<String>, RcExpr>),
+    Lam(Scope<Binder<String>, RcExpr>),
     /// Function application
     App(RcExpr, RcExpr),
 }
@@ -36,7 +36,7 @@ impl RcExpr {
     // FIXME: auto-derive this somehow!
     fn subst<N>(&self, name: &N, replacement: &RcExpr) -> RcExpr
     where
-        TVar<String>: PartialEq<N>,
+        Var<String>: PartialEq<N>,
     {
         match *self.inner {
             Expr::Var(ref n) if n == name => replacement.clone(),
@@ -72,13 +72,13 @@ fn test_eval() {
     // expr = (\x -> x) y
     let expr = RcExpr::from(Expr::App(
         RcExpr::from(Expr::Lam(Scope::new(
-            PVar::user("x"),
-            RcExpr::from(Expr::Var(TVar::user("x"))),
+            Binder::user("x"),
+            RcExpr::from(Expr::Var(Var::user("x"))),
         ))),
-        RcExpr::from(Expr::Var(TVar::user("y"))),
+        RcExpr::from(Expr::Var(Var::user("y"))),
     ));
 
-    assert_term_eq!(eval(&expr), RcExpr::from(Expr::Var(TVar::user("y"))),);
+    assert_term_eq!(eval(&expr), RcExpr::from(Expr::Var(Var::user("y"))),);
 }
 
 fn main() {}

--- a/moniker/examples/lc_multi.rs
+++ b/moniker/examples/lc_multi.rs
@@ -4,16 +4,16 @@
 #[macro_use]
 extern crate moniker;
 
-use moniker::{PVar, Scope, TVar};
+use moniker::{Binder, Scope, Var};
 use std::rc::Rc;
 
 /// Expressions
 #[derive(Debug, Clone, BoundTerm)]
 pub enum Expr {
     /// Variables
-    Var(TVar<String>),
+    Var(Var<String>),
     /// Lambda expressions
-    Lam(Scope<Vec<PVar<String>>, RcExpr>),
+    Lam(Scope<Vec<Binder<String>>, RcExpr>),
     /// Function application
     App(RcExpr, Vec<RcExpr>),
 }
@@ -36,7 +36,7 @@ impl RcExpr {
     // FIXME: auto-derive this somehow!
     fn substs<N>(&self, mappings: &[(N, RcExpr)]) -> RcExpr
     where
-        TVar<String>: PartialEq<N>,
+        Var<String>: PartialEq<N>,
     {
         match *self.inner {
             Expr::Var(ref n) => match mappings.iter().find(|&(n2, _)| n == n2) {
@@ -92,18 +92,18 @@ fn test_eval_const_lhs() {
     // expr = (fn(x, y) -> y)(a, b)
     let expr = RcExpr::from(Expr::App(
         RcExpr::from(Expr::Lam(Scope::new(
-            vec![PVar::user("x"), PVar::user("y")],
-            RcExpr::from(Expr::Var(TVar::user("y"))),
+            vec![Binder::user("x"), Binder::user("y")],
+            RcExpr::from(Expr::Var(Var::user("y"))),
         ))),
         vec![
-            RcExpr::from(Expr::Var(TVar::user("a"))),
-            RcExpr::from(Expr::Var(TVar::user("b"))),
+            RcExpr::from(Expr::Var(Var::user("a"))),
+            RcExpr::from(Expr::Var(Var::user("b"))),
         ],
     ));
 
     assert_term_eq!(
         eval(&expr).unwrap(),
-        RcExpr::from(Expr::Var(TVar::user("b"))),
+        RcExpr::from(Expr::Var(Var::user("b"))),
     );
 }
 
@@ -112,18 +112,18 @@ fn test_eval_const_rhs() {
     // expr = (fn(x, y) -> x)(a, b)
     let expr = RcExpr::from(Expr::App(
         RcExpr::from(Expr::Lam(Scope::new(
-            vec![PVar::user("x"), PVar::user("y")],
-            RcExpr::from(Expr::Var(TVar::user("x"))),
+            vec![Binder::user("x"), Binder::user("y")],
+            RcExpr::from(Expr::Var(Var::user("x"))),
         ))),
         vec![
-            RcExpr::from(Expr::Var(TVar::user("a"))),
-            RcExpr::from(Expr::Var(TVar::user("b"))),
+            RcExpr::from(Expr::Var(Var::user("a"))),
+            RcExpr::from(Expr::Var(Var::user("b"))),
         ],
     ));
 
     assert_term_eq!(
         eval(&expr).unwrap(),
-        RcExpr::from(Expr::Var(TVar::user("a"))),
+        RcExpr::from(Expr::Var(Var::user("a"))),
     );
 }
 

--- a/moniker/examples/stlc.rs
+++ b/moniker/examples/stlc.rs
@@ -9,7 +9,7 @@ extern crate im;
 extern crate moniker;
 
 use im::HashMap;
-use moniker::{BoundTerm, Embed, FreeVar, PVar, Scope, TVar};
+use moniker::{Binder, BoundTerm, Embed, FreeVar, Scope, Var};
 use std::rc::Rc;
 
 /// Types
@@ -58,9 +58,9 @@ pub enum Expr {
     /// Literals
     Literal(Literal),
     /// Variables
-    Var(TVar<String>),
+    Var(Var<String>),
     /// Lambda expressions, with an optional type annotation for the parameter
-    Lam(Scope<(PVar<String>, Embed<Option<RcType>>), RcExpr>),
+    Lam(Scope<(Binder<String>, Embed<Option<RcType>>), RcExpr>),
     /// Function application
     App(RcExpr, RcExpr),
 }
@@ -83,7 +83,7 @@ impl RcExpr {
     // FIXME: auto-derive this somehow!
     fn subst<N>(&self, name: &N, replacement: &RcExpr) -> RcExpr
     where
-        TVar<String>: PartialEq<N>,
+        Var<String>: PartialEq<N>,
     {
         match *self.inner {
             Expr::Ann(ref expr, ref ty) => {
@@ -202,8 +202,8 @@ pub fn infer(context: &Context, expr: &RcExpr) -> Result<RcType, String> {
 fn test_infer() {
     // expr = (\x : Int -> x)
     let expr = RcExpr::from(Expr::Lam(Scope::new(
-        (PVar::user("x"), Embed(Some(RcType::from(Type::Int)))),
-        RcExpr::from(Expr::Var(TVar::user("x"))),
+        (Binder::user("x"), Embed(Some(RcType::from(Type::Int)))),
+        RcExpr::from(Expr::Var(Var::user("x"))),
     )));
 
     assert_term_eq!(

--- a/moniker/src/embed.rs
+++ b/moniker/src/embed.rs
@@ -1,5 +1,5 @@
 use bound::{BoundPattern, BoundTerm, Permutations, ScopeState};
-use var::{FreeVar, PVar, PVarIndex, PVarOffset};
+use var::{Binder, BinderIndex, BinderOffset, FreeVar};
 
 /// Embed a term in a pattern
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -25,11 +25,11 @@ where
         self.0.open_term(state, pattern);
     }
 
-    fn find_pvar_index(&self, _: &FreeVar<Ident>) -> Result<PVarIndex, PVarOffset> {
-        Err(PVarOffset(0))
+    fn find_binder_index(&self, _: &FreeVar<Ident>) -> Result<BinderIndex, BinderOffset> {
+        Err(BinderOffset(0))
     }
 
-    fn find_pvar_at_offset(&self, offset: PVarOffset) -> Result<PVar<Ident>, PVarOffset> {
+    fn find_binder_at_offset(&self, offset: BinderOffset) -> Result<Binder<Ident>, BinderOffset> {
         Err(offset)
     }
 }

--- a/moniker/src/ignore.rs
+++ b/moniker/src/ignore.rs
@@ -1,5 +1,5 @@
 use bound::{BoundPattern, BoundTerm, Permutations, ScopeState};
-use var::{FreeVar, PVar, PVarIndex, PVarOffset, TVar};
+use var::{Binder, BinderIndex, BinderOffset, FreeVar, Var};
 
 /// Data that does not participate in name binding
 ///
@@ -17,9 +17,9 @@ impl<Ident, T> BoundTerm<Ident> for Ignore<T> {
 
     fn open_term(&mut self, _: ScopeState, _: &impl BoundPattern<Ident>) {}
 
-    fn visit_vars(&self, _: &mut impl FnMut(&TVar<Ident>)) {}
+    fn visit_vars(&self, _: &mut impl FnMut(&Var<Ident>)) {}
 
-    fn visit_mut_vars(&mut self, _: &mut impl FnMut(&mut TVar<Ident>)) {}
+    fn visit_mut_vars(&mut self, _: &mut impl FnMut(&mut Var<Ident>)) {}
 }
 
 impl<Ident, T> BoundPattern<Ident> for Ignore<T> {
@@ -35,11 +35,11 @@ impl<Ident, T> BoundPattern<Ident> for Ignore<T> {
 
     fn open_pattern(&mut self, _: ScopeState, _: &impl BoundPattern<Ident>) {}
 
-    fn find_pvar_index(&self, _: &FreeVar<Ident>) -> Result<PVarIndex, PVarOffset> {
-        Err(PVarOffset(0))
+    fn find_binder_index(&self, _: &FreeVar<Ident>) -> Result<BinderIndex, BinderOffset> {
+        Err(BinderOffset(0))
     }
 
-    fn find_pvar_at_offset(&self, offset: PVarOffset) -> Result<PVar<Ident>, PVarOffset> {
+    fn find_binder_at_offset(&self, offset: BinderOffset) -> Result<Binder<Ident>, BinderOffset> {
         Err(offset)
     }
 }

--- a/moniker/src/lib.rs
+++ b/moniker/src/lib.rs
@@ -11,7 +11,7 @@
 //! extern crate moniker;
 //!
 //! use std::rc::Rc;
-//! use moniker::{Embed, Nest, PVar, Scope, TVar};
+//! use moniker::{Embed, Nest, Binder, Scope, Var};
 //!
 //! # #[cfg(feature = "moniker-derive")]
 //! #[derive(Debug, Clone, BoundTerm)]
@@ -23,9 +23,9 @@
 //! # #[cfg(feature = "moniker-derive")]
 //! #[derive(Debug, Clone, BoundTerm)]
 //! pub enum Expr {
-//!     Var(TVar<String>),
-//!     Lam(Scope<(PVar<String>, Embed<Rc<Type>>), Rc<Expr>>),
-//!     Let(Scope<Nest<(PVar<String>, Embed<(Rc<Type>, Rc<Expr>)>)>, Rc<Expr>>),
+//!     Var(Var<String>),
+//!     Lam(Scope<(Binder<String>, Embed<Rc<Type>>), Rc<Expr>>),
+//!     Let(Scope<Nest<(Binder<String>, Embed<(Rc<Type>, Rc<Expr>)>)>, Rc<Expr>>),
 //!     App(Rc<Expr>, Rc<Expr>),
 //! }
 //! # fn main() {}
@@ -41,22 +41,22 @@
 //!
 //! Terms are data types that implement the [`BoundTerm`] trait.
 //!
-//! - [`TVar<Ident>`]: A variable that is either free or bound
+//! - [`Var<Ident>`]: A variable that is either free or bound
 //! - [`Scope<P: BoundPattern<Ident>, T: BoundTerm<Ident>>`]: bind the term `T` using the pattern `P`
 //!
 //! ## Patterns
 //!
 //! Patterns are data types that implement the [`BoundPattern`] trait.
 //!
-//! - [`PVar<Ident>`]: Captures a free variables within a term, but is ignored for alpha equality
+//! - [`Binder<Ident>`]: Captures a free variables within a term, but is ignored for alpha equality
 //! - [`Ignore<T>`]: Ignores `T` when comparing for alpha equality
 //! - [`Embed<T: BoundTerm<Ident>>`]: Embed a term `T` in a pattern
 //! - [`Nest<P: BoundPattern<Ident>>`]: Multiple nested binding patterns
 //! - [`Rec<P: BoundPattern<Ident>>`]: Recursively bind a pattern in itself
 //!
-//! [`TVar<Ident>`]: enum.TVar.html
+//! [`Var<Ident>`]: enum.Var.html
 //! [`Scope<P: BoundPattern<Ident>, T: BoundTerm<Ident>>`]: struct.Scope.html
-//! [`PVar<Ident>`]: enum.PVar.html
+//! [`Binder<Ident>`]: enum.Binder.html
 //! [`Ignore<T>`]: struct.Ignore.html
 //! [`Embed<T: BoundTerm<Ident>>`]: struct.Embed.html
 //! [`Nest<P: BoundPattern<Ident>>`]: struct.Nest.html
@@ -95,4 +95,4 @@ pub use self::ignore::Ignore;
 pub use self::nest::Nest;
 pub use self::rec::Rec;
 pub use self::scope::Scope;
-pub use self::var::{FreeVar, GenId, PVar, PVarIndex, PVarOffset, ScopeOffset, TVar};
+pub use self::var::{Binder, BinderIndex, BinderOffset, FreeVar, GenId, ScopeOffset, Var};

--- a/moniker/src/nest.rs
+++ b/moniker/src/nest.rs
@@ -1,5 +1,5 @@
 use bound::{BoundPattern, Permutations, ScopeState};
-use var::{FreeVar, PVar, PVarIndex, PVarOffset};
+use var::{Binder, BinderIndex, BinderOffset, FreeVar};
 
 /// Nested binding patterns
 ///
@@ -84,11 +84,11 @@ where
         }
     }
 
-    fn find_pvar_index(&self, free_var: &FreeVar<Ident>) -> Result<PVarIndex, PVarOffset> {
-        <[P]>::find_pvar_index(&self.unsafe_patterns, free_var)
+    fn find_binder_index(&self, free_var: &FreeVar<Ident>) -> Result<BinderIndex, BinderOffset> {
+        <[P]>::find_binder_index(&self.unsafe_patterns, free_var)
     }
 
-    fn find_pvar_at_offset(&self, offset: PVarOffset) -> Result<PVar<Ident>, PVarOffset> {
-        <[P]>::find_pvar_at_offset(&self.unsafe_patterns, offset)
+    fn find_binder_at_offset(&self, offset: BinderOffset) -> Result<Binder<Ident>, BinderOffset> {
+        <[P]>::find_binder_at_offset(&self.unsafe_patterns, offset)
     }
 }

--- a/moniker/src/rec.rs
+++ b/moniker/src/rec.rs
@@ -1,5 +1,5 @@
 use bound::{BoundPattern, Permutations, ScopeState};
-use var::{FreeVar, PVar, PVarIndex, PVarOffset};
+use var::{Binder, BinderIndex, BinderOffset, FreeVar};
 
 /// Recursively bind a pattern in itself
 ///
@@ -54,11 +54,11 @@ where
         self.unsafe_pattern.open_pattern(state, pattern);
     }
 
-    fn find_pvar_index(&self, free_var: &FreeVar<Ident>) -> Result<PVarIndex, PVarOffset> {
-        self.unsafe_pattern.find_pvar_index(free_var)
+    fn find_binder_index(&self, free_var: &FreeVar<Ident>) -> Result<BinderIndex, BinderOffset> {
+        self.unsafe_pattern.find_binder_index(free_var)
     }
 
-    fn find_pvar_at_offset(&self, offset: PVarOffset) -> Result<PVar<Ident>, PVarOffset> {
-        self.unsafe_pattern.find_pvar_at_offset(offset)
+    fn find_binder_at_offset(&self, offset: BinderOffset) -> Result<Binder<Ident>, BinderOffset> {
+        self.unsafe_pattern.find_binder_at_offset(offset)
     }
 }

--- a/moniker/src/scope.rs
+++ b/moniker/src/scope.rs
@@ -1,7 +1,7 @@
 use std::hash::Hash;
 
 use bound::{BoundPattern, BoundTerm, Permutations, ScopeState};
-use var::TVar;
+use var::Var;
 
 /// A bound scope
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -100,11 +100,11 @@ where
         self.unsafe_body.open_term(state.incr(), pattern);
     }
 
-    fn visit_vars(&self, on_var: &mut impl FnMut(&TVar<Ident>)) {
+    fn visit_vars(&self, on_var: &mut impl FnMut(&Var<Ident>)) {
         self.unsafe_body.visit_vars(on_var);
     }
 
-    fn visit_mut_vars(&mut self, on_var: &mut impl FnMut(&mut TVar<Ident>)) {
+    fn visit_mut_vars(&mut self, on_var: &mut impl FnMut(&mut Var<Ident>)) {
         self.unsafe_body.visit_mut_vars(on_var);
     }
 }


### PR DESCRIPTION
Given discussions with @kleimkuhler in the gitter channel, I've decided to rename these types to improve clarity. This means that patterns are a little more verbose, but I think that's ok!