### PR TITLE
Remove unused binder variant

### DIFF
--- a/moniker/examples/lc_letrec.rs
+++ b/moniker/examples/lc_letrec.rs
@@ -91,10 +91,7 @@ pub fn eval(expr: &RcExpr) -> RcExpr {
             // garbage collect, if possible
             // FIXME: `free_vars` is slow! We probably want this to be faster - see issue #10
             let fvs = body.free_vars();
-            if bindings.iter().any(|&(ref binder, _)| match *binder {
-                Binder::Free(ref binder) => fvs.contains(binder),
-                _ => panic!("encountered a bound variable"),
-            }) {
+            if bindings.iter().any(|&(Binder(ref fv), _)| fvs.contains(fv)) {
                 RcExpr::from(Expr::LetRec(Scope::new(Rec::new(&bindings), body)))
             } else {
                 eval(&body)

--- a/moniker/examples/stlc.rs
+++ b/moniker/examples/stlc.rs
@@ -125,11 +125,7 @@ type Context = HashMap<FreeVar<String>, RcType>;
 pub fn check(context: &Context, expr: &RcExpr, expected_ty: &RcType) -> Result<(), String> {
     match (&*expr.inner, &*expected_ty.inner) {
         (&Expr::Lam(ref scope), &Type::Arrow(ref param_ty, ref ret_ty)) => {
-            if let ((binder, Embed(None)), body) = scope.clone().unbind() {
-                // FIXME: Ick!
-                let free_var = binder
-                    .try_into_free_var()
-                    .expect("encountered a bound variable");
+            if let ((Binder(free_var), Embed(None)), body) = scope.clone().unbind() {
                 check(&context.insert(free_var, param_ty.clone()), &body, ret_ty)?;
                 return Ok(());
             }
@@ -159,21 +155,13 @@ pub fn infer(context: &Context, expr: &RcExpr) -> Result<RcType, String> {
         Expr::Literal(Literal::Int(_)) => Ok(RcType::from(Type::Int)),
         Expr::Literal(Literal::Float(_)) => Ok(RcType::from(Type::Float)),
         Expr::Literal(Literal::String(_)) => Ok(RcType::from(Type::String)),
-        Expr::Var(ref var) => match context.get(
-            // FIXME: Ick!
-            &var.clone()
-                .try_into_free_var()
-                .expect("encountered a bound variable"),
-        ) {
+        Expr::Var(Var::Free(ref free_var)) => match context.get(free_var) {
             Some(term) => Ok((*term).clone()),
-            None => Err(format!("`{:?}` not found in `{:?}`", var, context)),
+            None => Err(format!("`{:?}` not found in `{:?}`", free_var, context)),
         },
+        Expr::Var(Var::Bound(_, _, _)) => panic!("encountered a bound variable"),
         Expr::Lam(ref scope) => match scope.clone().unbind() {
-            ((binder, Embed(Some(ann))), body) => {
-                // FIXME: Ick!
-                let free_var = binder
-                    .try_into_free_var()
-                    .expect("encountered a bound variable");
+            ((Binder(free_var), Embed(Some(ann))), body) => {
                 let body_ty = infer(&context.insert(free_var, ann.clone()), &body)?;
                 Ok(RcType::from(Type::Arrow(ann, body_ty)))
             },

--- a/moniker/src/bound.rs
+++ b/moniker/src/bound.rs
@@ -96,7 +96,7 @@ impl<N: PartialEq + Clone> BoundTerm<N> for Var<N> {
         *self = match *self {
             Var::Bound(scope, binder_index, _) if scope == state.depth() => {
                 match pattern.find_binder_at_offset(binder_index.0) {
-                    Ok(binder) => binder.to_var(state.depth()),
+                    Ok(Binder(binder)) => Var::Free(binder),
                     Err(_) => {
                         // FIXME: better error?
                         panic!(
@@ -502,9 +502,10 @@ where
     fn open_pattern(&mut self, _: ScopeState, _: &impl BoundPattern<N>) {}
 
     fn find_binder_index(&self, free_var: &FreeVar<N>) -> Result<BinderIndex, BinderOffset> {
-        match *self {
-            Binder::Free(ref n) if n == free_var => Ok(BinderIndex(BinderOffset(0))),
-            Binder::Free(_) | Binder::Bound(_, _) => Err(BinderOffset(1)),
+        if self == free_var {
+            Ok(BinderIndex(BinderOffset(0)))
+        } else {
+            Err(BinderOffset(1))
         }
     }
 


### PR DESCRIPTION
I thought we needed the `Binder::Bound` variant, but it seems like we don’t (at least for now)! This also helps us clean up a bunch of code in the examples.