### PR TITLE
BoundPattern and BoundTerm API cleanups

### DIFF
--- a/moniker-derive/src/lib.rs
+++ b/moniker-derive/src/lib.rs
@@ -63,7 +63,6 @@ fn bound_term_derive(mut s: Structure) -> proc_macro2::TokenStream {
     let visit_vars_body = s.each(|bi| {
         quote!{ moniker::BoundTerm::<String>::visit_vars(#bi, __on_var); }
     });
-
     s.bind_with(|_| BindStyle::RefMut);
     let visit_mut_vars_body = s.each(|bi| {
         quote!{ moniker::BoundTerm::<String>::visit_mut_vars(#bi, __on_var); }
@@ -148,14 +147,6 @@ fn bound_pattern_derive(mut s: Structure) -> proc_macro2::TokenStream {
     };
 
     s.bind_with(|_| BindStyle::RefMut);
-    let freshen_body = s.each(|bi| {
-        quote!{ moniker::BoundPattern::<String>::freshen(#bi, __permutations); }
-    });
-    let swaps_body = s.each(|bi| {
-        quote!{ moniker::BoundPattern::<String>::swaps(#bi, __permutations); }
-    });
-
-    s.bind_with(|_| BindStyle::RefMut);
     let close_pattern_body = s.each(|bi| {
         quote!{ moniker::BoundPattern::<String>::close_pattern(#bi, __state, __pattern); }
     });
@@ -164,21 +155,12 @@ fn bound_pattern_derive(mut s: Structure) -> proc_macro2::TokenStream {
     });
 
     s.bind_with(|_| BindStyle::Ref);
-    let find_binder_index_body = s.each(|bi| {
-        quote! {
-            match #bi.find_binder_index(__free_var) {
-                Ok(__binder_index) => return Ok(__binder_index + __skipped),
-                Err(__next_skipped) => __skipped += __next_skipped,
-            };
-        }
+    let visit_binders_body = s.each(|bi| {
+        quote!{ moniker::BoundPattern::<String>::visit_binders(#bi, __on_binder); }
     });
-    let find_binder_at_offset_body = s.each(|bi| {
-        quote! {
-            match #bi.find_binder_at_offset(__offset) {
-                Ok(__binder) => return Ok(__binder),
-                Err(__next_offset) => __offset = __next_offset,
-            };
-        }
+    s.bind_with(|_| BindStyle::RefMut);
+    let visit_mut_binders_body = s.each(|bi| {
+        quote!{ moniker::BoundPattern::<String>::visit_mut_binders(#bi, __on_binder); }
     });
 
     s.gen_impl(quote! {
@@ -187,14 +169,6 @@ fn bound_pattern_derive(mut s: Structure) -> proc_macro2::TokenStream {
         gen impl moniker::BoundPattern<String> for @Self {
             fn pattern_eq(&self, other: &Self) -> bool {
                 match (self, other) { #pattern_eq_body }
-            }
-
-            fn freshen(&mut self, __permutations: &mut moniker::Permutations<String>) {
-                match *self { #freshen_body }
-            }
-
-            fn swaps(&mut self, __permutations: &moniker::Permutations<String>) {
-                match *self { #swaps_body }
             }
 
             fn close_pattern(
@@ -213,21 +187,15 @@ fn bound_pattern_derive(mut s: Structure) -> proc_macro2::TokenStream {
                 match *self { #open_pattern_body }
             }
 
-            fn find_binder_index(
-                &self,
-                __free_var: &moniker::FreeVar<String>,
-            ) -> Result<moniker::BinderIndex, moniker::BinderOffset> {
-                let mut __skipped = moniker::BinderOffset(0);
-                match *self { #find_binder_index_body }
-                Err(__skipped)
+            fn visit_binders(&self, __on_binder: &mut impl FnMut(&moniker::Binder<String>)) {
+                match *self { #visit_binders_body }
             }
 
-            fn find_binder_at_offset(
-                &self,
-                mut __offset: moniker::BinderOffset,
-            ) -> Result<moniker::Binder<String>, moniker::BinderOffset> {
-                match *self { #find_binder_at_offset_body }
-                Err(__offset)
+            fn visit_mut_binders(
+                &mut self,
+                __on_binder: &mut impl FnMut(&mut moniker::Binder<String>),
+            ) {
+                match *self { #visit_mut_binders_body }
             }
         }
     })

--- a/moniker-derive/src/lib.rs
+++ b/moniker-derive/src/lib.rs
@@ -53,10 +53,10 @@ fn bound_term_derive(mut s: Structure) -> proc_macro2::TokenStream {
 
     s.bind_with(|_| BindStyle::RefMut);
     let close_term_body = s.each(|bi| {
-        quote!{ moniker::BoundTerm::<String>::close_term(#bi, __state, __pattern); }
+        quote!{ moniker::BoundTerm::<String>::close_term(#bi, __state, __binders); }
     });
     let open_term_body = s.each(|bi| {
-        quote!{ moniker::BoundTerm::<String>::open_term(#bi, __state, __pattern); }
+        quote!{ moniker::BoundTerm::<String>::open_term(#bi, __state, __binders); }
     });
 
     s.bind_with(|_| BindStyle::Ref);
@@ -79,7 +79,7 @@ fn bound_term_derive(mut s: Structure) -> proc_macro2::TokenStream {
             fn close_term(
                 &mut self,
                 __state: moniker::ScopeState,
-                __pattern: &impl moniker::BoundPattern<String>,
+                __binders: &[moniker::Binder<String>],
             ) {
                 match *self { #close_term_body }
             }
@@ -87,7 +87,7 @@ fn bound_term_derive(mut s: Structure) -> proc_macro2::TokenStream {
             fn open_term(
                 &mut self,
                 __state: moniker::ScopeState,
-                __pattern: &impl moniker::BoundPattern<String>,
+                __binders: &[moniker::Binder<String>],
             ) {
                 match *self { #open_term_body }
             }
@@ -148,10 +148,10 @@ fn bound_pattern_derive(mut s: Structure) -> proc_macro2::TokenStream {
 
     s.bind_with(|_| BindStyle::RefMut);
     let close_pattern_body = s.each(|bi| {
-        quote!{ moniker::BoundPattern::<String>::close_pattern(#bi, __state, __pattern); }
+        quote!{ moniker::BoundPattern::<String>::close_pattern(#bi, __state, __binders); }
     });
     let open_pattern_body = s.each(|bi| {
-        quote!{ moniker::BoundPattern::<String>::open_pattern(#bi, __state, __pattern); }
+        quote!{ moniker::BoundPattern::<String>::open_pattern(#bi, __state, __binders); }
     });
 
     s.bind_with(|_| BindStyle::Ref);
@@ -174,7 +174,7 @@ fn bound_pattern_derive(mut s: Structure) -> proc_macro2::TokenStream {
             fn close_pattern(
                 &mut self,
                 __state: moniker::ScopeState,
-                __pattern: &impl moniker::BoundPattern<String>,
+                __binders: &[moniker::Binder<String>],
             ) {
                 match *self { #close_pattern_body }
             }
@@ -182,7 +182,7 @@ fn bound_pattern_derive(mut s: Structure) -> proc_macro2::TokenStream {
             fn open_pattern(
                 &mut self,
                 __state: moniker::ScopeState,
-                __pattern: &impl moniker::BoundPattern<String>,
+                __binders: &[moniker::Binder<String>],
             ) {
                 match *self { #open_pattern_body }
             }

--- a/moniker/examples/lc_letrec.rs
+++ b/moniker/examples/lc_letrec.rs
@@ -99,7 +99,7 @@ pub fn eval(expr: &RcExpr) -> RcExpr {
             // FIXME: `free_vars` is slow! We probably want this to be faster - see issue #10
             let fvs = body.free_vars();
             if bindings.iter().any(|&(Binder(ref fv), _)| fvs.contains(fv)) {
-                RcExpr::from(Expr::LetRec(Scope::new(Rec::new(&bindings), body)))
+                RcExpr::from(Expr::LetRec(Scope::new(Rec::new(bindings), body)))
             } else {
                 eval(&body)
             }
@@ -130,7 +130,7 @@ fn test_eval_let_rec() {
     //      in
     //          test
     let expr = RcExpr::from(Expr::LetRec(Scope::new(
-        Rec::new(&vec![
+        Rec::new(vec![
             (
                 Binder::user("test"),
                 Embed(RcExpr::from(Expr::App(

--- a/moniker/src/binder.rs
+++ b/moniker/src/binder.rs
@@ -84,8 +84,8 @@ impl<N> Binder<N> {
         Binder(FreeVar::user(ident))
     }
 
-    pub fn fresh(self) -> Binder<N> {
-        Binder(self.0.fresh())
+    pub fn freshen(self) -> Binder<N> {
+        Binder(self.0.freshen())
     }
 }
 

--- a/moniker/src/bound.rs
+++ b/moniker/src/bound.rs
@@ -399,7 +399,7 @@ where
 
 impl<N, T> BoundTerm<N> for [T]
 where
-    T: BoundTerm<N> + Clone,
+    T: BoundTerm<N>,
 {
     fn term_eq(&self, other: &[T]) -> bool {
         self.len() == other.len()
@@ -433,7 +433,7 @@ where
 
 impl<N, T> BoundTerm<N> for Vec<T>
 where
-    T: BoundTerm<N> + Clone,
+    T: BoundTerm<N>,
 {
     fn term_eq(&self, other: &Vec<T>) -> bool {
         <[T]>::term_eq(self, other)

--- a/moniker/src/bound.rs
+++ b/moniker/src/bound.rs
@@ -476,7 +476,7 @@ pub trait BoundPattern<N> {
         N: Clone + Eq + Hash,
     {
         self.visit_mut_binders(&mut |binder| {
-            let fresh = binder.clone().fresh();
+            let fresh = binder.clone().freshen();
             permutations.insert(binder.clone(), fresh.clone());
             *binder = fresh;
         })

--- a/moniker/src/embed.rs
+++ b/moniker/src/embed.rs
@@ -17,12 +17,12 @@ where
 
     fn swaps(&mut self, _: &Permutations<N>) {}
 
-    fn close_pattern(&mut self, state: ScopeState, pattern: &impl BoundPattern<N>) {
-        self.0.close_term(state, pattern);
+    fn close_pattern(&mut self, state: ScopeState, binders: &[Binder<N>]) {
+        self.0.close_term(state, binders);
     }
 
-    fn open_pattern(&mut self, state: ScopeState, pattern: &impl BoundPattern<N>) {
-        self.0.open_term(state, pattern);
+    fn open_pattern(&mut self, state: ScopeState, binders: &[Binder<N>]) {
+        self.0.open_term(state, binders);
     }
 
     fn visit_binders(&self, _: &mut impl FnMut(&Binder<N>)) {}

--- a/moniker/src/embed.rs
+++ b/moniker/src/embed.rs
@@ -1,6 +1,5 @@
-use binder::{Binder, BinderIndex, BinderOffset};
+use binder::Binder;
 use bound::{BoundPattern, BoundTerm, Permutations, ScopeState};
-use free_var::FreeVar;
 
 /// Embed a term in a pattern
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -26,11 +25,7 @@ where
         self.0.open_term(state, pattern);
     }
 
-    fn find_binder_index(&self, _: &FreeVar<N>) -> Result<BinderIndex, BinderOffset> {
-        Err(BinderOffset(0))
-    }
+    fn visit_binders(&self, _: &mut impl FnMut(&Binder<N>)) {}
 
-    fn find_binder_at_offset(&self, offset: BinderOffset) -> Result<Binder<N>, BinderOffset> {
-        Err(offset)
-    }
+    fn visit_mut_binders(&mut self, _: &mut impl FnMut(&mut Binder<N>)) {}
 }

--- a/moniker/src/free_var.rs
+++ b/moniker/src/free_var.rs
@@ -42,7 +42,7 @@ impl<N> FreeVar<N> {
         FreeVar::User(ident.into())
     }
 
-    pub fn fresh(self) -> FreeVar<N> {
+    pub fn freshen(self) -> FreeVar<N> {
         match self {
             FreeVar::User(name) => FreeVar::Gen(GenId::fresh(), Some(name)),
             FreeVar::Gen(_, _) => self,

--- a/moniker/src/ignore.rs
+++ b/moniker/src/ignore.rs
@@ -14,9 +14,9 @@ impl<N, T> BoundTerm<N> for Ignore<T> {
         true
     }
 
-    fn close_term(&mut self, _: ScopeState, _: &impl BoundPattern<N>) {}
+    fn close_term(&mut self, _: ScopeState, _: &[Binder<N>]) {}
 
-    fn open_term(&mut self, _: ScopeState, _: &impl BoundPattern<N>) {}
+    fn open_term(&mut self, _: ScopeState, _: &[Binder<N>]) {}
 
     fn visit_vars(&self, _: &mut impl FnMut(&Var<N>)) {}
 
@@ -32,9 +32,9 @@ impl<N, T> BoundPattern<N> for Ignore<T> {
 
     fn swaps(&mut self, _: &Permutations<N>) {}
 
-    fn close_pattern(&mut self, _: ScopeState, _: &impl BoundPattern<N>) {}
+    fn close_pattern(&mut self, _: ScopeState, _: &[Binder<N>]) {}
 
-    fn open_pattern(&mut self, _: ScopeState, _: &impl BoundPattern<N>) {}
+    fn open_pattern(&mut self, _: ScopeState, _: &[Binder<N>]) {}
 
     fn visit_binders(&self, _: &mut impl FnMut(&Binder<N>)) {}
 

--- a/moniker/src/ignore.rs
+++ b/moniker/src/ignore.rs
@@ -1,6 +1,5 @@
-use binder::{Binder, BinderIndex, BinderOffset};
+use binder::Binder;
 use bound::{BoundPattern, BoundTerm, Permutations, ScopeState};
-use free_var::FreeVar;
 use var::Var;
 
 /// Data that does not participate in name binding
@@ -37,11 +36,7 @@ impl<N, T> BoundPattern<N> for Ignore<T> {
 
     fn open_pattern(&mut self, _: ScopeState, _: &impl BoundPattern<N>) {}
 
-    fn find_binder_index(&self, _: &FreeVar<N>) -> Result<BinderIndex, BinderOffset> {
-        Err(BinderOffset(0))
-    }
+    fn visit_binders(&self, _: &mut impl FnMut(&Binder<N>)) {}
 
-    fn find_binder_at_offset(&self, offset: BinderOffset) -> Result<Binder<N>, BinderOffset> {
-        Err(offset)
-    }
+    fn visit_mut_binders(&mut self, _: &mut impl FnMut(&mut Binder<N>)) {}
 }

--- a/moniker/src/nest.rs
+++ b/moniker/src/nest.rs
@@ -1,6 +1,5 @@
-use binder::{Binder, BinderIndex, BinderOffset};
-use bound::{BoundPattern, Permutations, ScopeState};
-use free_var::FreeVar;
+use binder::Binder;
+use bound::{BoundPattern, ScopeState};
 
 /// Nested binding patterns
 ///
@@ -63,14 +62,6 @@ where
         <[P]>::pattern_eq(&self.unsafe_patterns, &other.unsafe_patterns)
     }
 
-    fn freshen(&mut self, permutations: &mut Permutations<N>) {
-        <[P]>::freshen(&mut self.unsafe_patterns, permutations)
-    }
-
-    fn swaps(&mut self, permutations: &Permutations<N>) {
-        <[P]>::swaps(&mut self.unsafe_patterns, permutations)
-    }
-
     fn close_pattern(&mut self, mut state: ScopeState, pattern: &impl BoundPattern<N>) {
         for elem in &mut self.unsafe_patterns {
             elem.close_pattern(state, pattern);
@@ -85,11 +76,11 @@ where
         }
     }
 
-    fn find_binder_index(&self, free_var: &FreeVar<N>) -> Result<BinderIndex, BinderOffset> {
-        <[P]>::find_binder_index(&self.unsafe_patterns, free_var)
+    fn visit_binders(&self, on_binder: &mut impl FnMut(&Binder<N>)) {
+        <[P]>::visit_binders(&self.unsafe_patterns, on_binder);
     }
 
-    fn find_binder_at_offset(&self, offset: BinderOffset) -> Result<Binder<N>, BinderOffset> {
-        <[P]>::find_binder_at_offset(&self.unsafe_patterns, offset)
+    fn visit_mut_binders(&mut self, on_binder: &mut impl FnMut(&mut Binder<N>)) {
+        <[P]>::visit_mut_binders(&mut self.unsafe_patterns, on_binder);
     }
 }

--- a/moniker/src/rec.rs
+++ b/moniker/src/rec.rs
@@ -1,6 +1,5 @@
-use binder::{Binder, BinderIndex, BinderOffset};
-use bound::{BoundPattern, Permutations, ScopeState};
-use free_var::FreeVar;
+use binder::Binder;
+use bound::{BoundPattern, ScopeState};
 
 /// Recursively bind a pattern in itself
 ///
@@ -39,14 +38,6 @@ where
         P::pattern_eq(&self.unsafe_pattern, &other.unsafe_pattern)
     }
 
-    fn freshen(&mut self, permutations: &mut Permutations<N>) {
-        self.unsafe_pattern.freshen(permutations)
-    }
-
-    fn swaps(&mut self, permutations: &Permutations<N>) {
-        self.unsafe_pattern.swaps(permutations)
-    }
-
     fn close_pattern(&mut self, state: ScopeState, pattern: &impl BoundPattern<N>) {
         self.unsafe_pattern.close_pattern(state, pattern);
     }
@@ -55,11 +46,11 @@ where
         self.unsafe_pattern.open_pattern(state, pattern);
     }
 
-    fn find_binder_index(&self, free_var: &FreeVar<N>) -> Result<BinderIndex, BinderOffset> {
-        self.unsafe_pattern.find_binder_index(free_var)
+    fn visit_binders(&self, on_binder: &mut impl FnMut(&Binder<N>)) {
+        self.unsafe_pattern.visit_binders(on_binder);
     }
 
-    fn find_binder_at_offset(&self, offset: BinderOffset) -> Result<Binder<N>, BinderOffset> {
-        self.unsafe_pattern.find_binder_at_offset(offset)
+    fn visit_mut_binders(&mut self, on_binder: &mut impl FnMut(&mut Binder<N>)) {
+        self.unsafe_pattern.visit_mut_binders(on_binder);
     }
 }

--- a/moniker/src/scope.rs
+++ b/moniker/src/scope.rs
@@ -45,11 +45,10 @@ impl<P, T> Scope<P, T> {
         let mut pattern = self.unsafe_pattern;
         let mut body = self.unsafe_body;
 
-        {
-            let mut permutations = Permutations::new();
-            pattern.freshen(&mut permutations); // FIXME: `permutations` is unused here!
-            body.open_term(ScopeState::new(), &pattern.binders());
-        }
+        // Freshen the pattern in preparation for opening
+        pattern.visit_mut_binders(&mut |binder| *binder = binder.clone().freshen());
+        // Use the freshened binders when opening the body
+        body.open_term(ScopeState::new(), &pattern.binders());
 
         (pattern, body)
     }

--- a/moniker/src/scope.rs
+++ b/moniker/src/scope.rs
@@ -1,5 +1,6 @@
 use std::hash::Hash;
 
+use binder::Binder;
 use bound::{BoundPattern, BoundTerm, Permutations, ScopeState};
 use var::Var;
 
@@ -22,10 +23,11 @@ impl<P, T> Scope<P, T> {
     /// Create a new scope by binding a term with the given pattern
     pub fn new<N>(pattern: P, mut body: T) -> Scope<P, T>
     where
+        N: Clone,
         P: BoundPattern<N>,
         T: BoundTerm<N>,
     {
-        body.close_term(ScopeState::new(), &pattern);
+        body.close_term(ScopeState::new(), &pattern.binders());
 
         Scope {
             unsafe_pattern: pattern,
@@ -46,7 +48,7 @@ impl<P, T> Scope<P, T> {
         {
             let mut permutations = Permutations::new();
             pattern.freshen(&mut permutations); // FIXME: `permutations` is unused here!
-            body.open_term(ScopeState::new(), &pattern);
+            body.open_term(ScopeState::new(), &pattern.binders());
         }
 
         (pattern, body)
@@ -72,8 +74,8 @@ impl<P, T> Scope<P, T> {
             let mut permutations = Permutations::new();
             self_pattern.freshen(&mut permutations);
             other_pattern.swaps(&permutations);
-            self_body.open_term(ScopeState::new(), &self_pattern);
-            other_body.open_term(ScopeState::new(), &other_pattern);
+            self_body.open_term(ScopeState::new(), &self_pattern.binders());
+            other_body.open_term(ScopeState::new(), &other_pattern.binders());
         }
 
         (self_pattern, self_body, other_pattern, other_body)
@@ -90,14 +92,14 @@ where
             && T::term_eq(&self.unsafe_body, &other.unsafe_body)
     }
 
-    fn close_term(&mut self, state: ScopeState, pattern: &impl BoundPattern<N>) {
-        self.unsafe_pattern.close_pattern(state, pattern);
-        self.unsafe_body.close_term(state.incr(), pattern);
+    fn close_term(&mut self, state: ScopeState, binders: &[Binder<N>]) {
+        self.unsafe_pattern.close_pattern(state, binders);
+        self.unsafe_body.close_term(state.incr(), binders);
     }
 
-    fn open_term(&mut self, state: ScopeState, pattern: &impl BoundPattern<N>) {
-        self.unsafe_pattern.open_pattern(state, pattern);
-        self.unsafe_body.open_term(state.incr(), pattern);
+    fn open_term(&mut self, state: ScopeState, binders: &[Binder<N>]) {
+        self.unsafe_pattern.open_pattern(state, binders);
+        self.unsafe_body.open_term(state.incr(), binders);
     }
 
     fn visit_vars(&self, on_var: &mut impl FnMut(&Var<N>)) {

--- a/moniker/src/scope.rs
+++ b/moniker/src/scope.rs
@@ -36,7 +36,7 @@ impl<P, T> Scope<P, T> {
     /// Unbind a term, returning the freshened pattern and body
     pub fn unbind<N>(self) -> (P, T)
     where
-        N: Eq + Hash,
+        N: Clone + Eq + Hash,
         P: BoundPattern<N>,
         T: BoundTerm<N>,
     {
@@ -57,7 +57,7 @@ impl<P, T> Scope<P, T> {
     /// The fresh names in the first pattern with be used for the second pattern
     pub fn unbind2<N, P2, T2>(self, other: Scope<P2, T2>) -> (P, T, P2, T2)
     where
-        N: Eq + Hash,
+        N: Clone + Eq + Hash,
         P: BoundPattern<N>,
         T: BoundTerm<N>,
         P2: BoundPattern<N>,


### PR DESCRIPTION
In a step beyond simply porting some of the stuff that Unbound was doing, I've updated the API to (hopefully) be a little-less obtuse. Instead of dispatching off the patterns themselves whenever we open and close terms and patterns, we pass in an array of binders.

I've added some 'visitor methods' to the `BoundPattern` trait. These take a callback that is executed whenever a binder is passed over. This allows us to implement `BoundPattern::{freshen, swaps, binders}` as default methods.