### PR TITLE
Reduce retreversals for Nest type 

### DIFF
--- a/moniker-derive/Cargo.toml
+++ b/moniker-derive/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "moniker-derive"
-version = "0.3.2"
+version = "0.4.0"
 readme = "./README.md"
 license = "Apache-2.0"
 authors = ["Brendan Zabarauskas <bjzaba@yahoo.com.au>"]

--- a/moniker-derive/src/lib.rs
+++ b/moniker-derive/src/lib.rs
@@ -53,10 +53,10 @@ fn bound_term_derive(mut s: Structure) -> proc_macro2::TokenStream {
 
     s.bind_with(|_| BindStyle::RefMut);
     let close_term_body = s.each(|bi| {
-        quote!{ moniker::BoundTerm::<String>::close_term(#bi, __state, __binders); }
+        quote!{ moniker::BoundTerm::<String>::close_term(#bi, __state, __on_free); }
     });
     let open_term_body = s.each(|bi| {
-        quote!{ moniker::BoundTerm::<String>::open_term(#bi, __state, __binders); }
+        quote!{ moniker::BoundTerm::<String>::open_term(#bi, __state, __on_bound); }
     });
 
     s.bind_with(|_| BindStyle::Ref);
@@ -79,7 +79,7 @@ fn bound_term_derive(mut s: Structure) -> proc_macro2::TokenStream {
             fn close_term(
                 &mut self,
                 __state: moniker::ScopeState,
-                __binders: &[moniker::Binder<String>],
+                __on_free: &impl moniker::OnFreeFn<String>,
             ) {
                 match *self { #close_term_body }
             }
@@ -87,7 +87,7 @@ fn bound_term_derive(mut s: Structure) -> proc_macro2::TokenStream {
             fn open_term(
                 &mut self,
                 __state: moniker::ScopeState,
-                __binders: &[moniker::Binder<String>],
+                __on_bound: &impl moniker::OnBoundFn<String>,
             ) {
                 match *self { #open_term_body }
             }
@@ -148,10 +148,10 @@ fn bound_pattern_derive(mut s: Structure) -> proc_macro2::TokenStream {
 
     s.bind_with(|_| BindStyle::RefMut);
     let close_pattern_body = s.each(|bi| {
-        quote!{ moniker::BoundPattern::<String>::close_pattern(#bi, __state, __binders); }
+        quote!{ moniker::BoundPattern::<String>::close_pattern(#bi, __state, __on_free); }
     });
     let open_pattern_body = s.each(|bi| {
-        quote!{ moniker::BoundPattern::<String>::open_pattern(#bi, __state, __binders); }
+        quote!{ moniker::BoundPattern::<String>::open_pattern(#bi, __state, __on_bound); }
     });
 
     s.bind_with(|_| BindStyle::Ref);
@@ -174,7 +174,7 @@ fn bound_pattern_derive(mut s: Structure) -> proc_macro2::TokenStream {
             fn close_pattern(
                 &mut self,
                 __state: moniker::ScopeState,
-                __binders: &[moniker::Binder<String>],
+                __on_free: &impl moniker::OnFreeFn<String>,
             ) {
                 match *self { #close_pattern_body }
             }
@@ -182,7 +182,7 @@ fn bound_pattern_derive(mut s: Structure) -> proc_macro2::TokenStream {
             fn open_pattern(
                 &mut self,
                 __state: moniker::ScopeState,
-                __binders: &[moniker::Binder<String>],
+                __on_bound: &impl moniker::OnBoundFn<String>,
             ) {
                 match *self { #open_pattern_body }
             }

--- a/moniker/Cargo.toml
+++ b/moniker/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "moniker"
-version = "0.3.2"
+version = "0.4.0"
 readme = "../README.md"
 license = "Apache-2.0"
 authors = ["Brendan Zabarauskas <bjzaba@yahoo.com.au>"]
@@ -30,7 +30,7 @@ default = ["moniker-derive"]
 
 [dependencies]
 lazy_static = "1.0"
-moniker-derive = { path = "../moniker-derive", version = "0.3.2", optional = true }
+moniker-derive = { path = "../moniker-derive", version = "0.4.0", optional = true }
 
 # Optional impls
 codespan = { version = "0.1.2", optional = true }

--- a/moniker/src/bound/codespan.rs
+++ b/moniker/src/bound/codespan.rs
@@ -7,14 +7,14 @@ use super::*;
 
 macro_rules! impl_bound_term_ignore {
     ($T:ty) => {
-        impl<N> BoundTerm<N> for $T {
+        impl<N: Clone + PartialEq> BoundTerm<N> for $T {
             fn term_eq(&self, _: &$T) -> bool {
                 true
             }
 
-            fn close_term(&mut self, _: ScopeState, _: &[Binder<N>]) {}
+            fn close_term(&mut self, _: ScopeState, _: &impl OnFreeFn<N>) {}
 
-            fn open_term(&mut self, _: ScopeState, _: &[Binder<N>]) {}
+            fn open_term(&mut self, _: ScopeState, _: &impl OnBoundFn<N>) {}
 
             fn visit_vars(&self, _: &mut impl FnMut(&Var<N>)) {}
 
@@ -32,14 +32,14 @@ impl_bound_term_ignore!(LineIndex);
 impl_bound_term_ignore!(LineNumber);
 impl_bound_term_ignore!(LineOffset);
 
-impl<N, T> BoundTerm<N> for Span<T> {
+impl<N: Clone + PartialEq, T> BoundTerm<N> for Span<T> {
     fn term_eq(&self, _: &Span<T>) -> bool {
         true
     }
 
-    fn close_term(&mut self, _: ScopeState, _: &[Binder<N>]) {}
+    fn close_term(&mut self, _: ScopeState, _: &impl OnFreeFn<N>) {}
 
-    fn open_term(&mut self, _: ScopeState, _: &[Binder<N>]) {}
+    fn open_term(&mut self, _: ScopeState, _: &impl OnBoundFn<N>) {}
 
     fn visit_vars(&self, _: &mut impl FnMut(&Var<N>)) {}
 
@@ -48,14 +48,14 @@ impl<N, T> BoundTerm<N> for Span<T> {
 
 macro_rules! impl_bound_pattern_ignore {
     ($T:ty) => {
-        impl<N> BoundPattern<N> for $T {
+        impl<N: Clone + PartialEq> BoundPattern<N> for $T {
             fn pattern_eq(&self, _: &$T) -> bool {
                 true
             }
 
-            fn close_pattern(&mut self, _: ScopeState, _: &[Binder<N>]) {}
+            fn close_pattern(&mut self, _: ScopeState, _: &impl OnFreeFn<N>) {}
 
-            fn open_pattern(&mut self, _: ScopeState, _: &[Binder<N>]) {}
+            fn open_pattern(&mut self, _: ScopeState, _: &impl OnBoundFn<N>) {}
 
             fn visit_binders(&self, _: &mut impl FnMut(&Binder<N>)) {}
 
@@ -73,14 +73,14 @@ impl_bound_pattern_ignore!(LineIndex);
 impl_bound_pattern_ignore!(LineNumber);
 impl_bound_pattern_ignore!(LineOffset);
 
-impl<N, T> BoundPattern<N> for Span<T> {
+impl<N: Clone + PartialEq, T> BoundPattern<N> for Span<T> {
     fn pattern_eq(&self, _: &Span<T>) -> bool {
         true
     }
 
-    fn close_pattern(&mut self, _: ScopeState, _: &[Binder<N>]) {}
+    fn close_pattern(&mut self, _: ScopeState, _: &impl OnFreeFn<N>) {}
 
-    fn open_pattern(&mut self, _: ScopeState, _: &[Binder<N>]) {}
+    fn open_pattern(&mut self, _: ScopeState, _: &impl OnBoundFn<N>) {}
 
     fn visit_binders(&self, _: &mut impl FnMut(&Binder<N>)) {}
 

--- a/moniker/src/bound/im.rs
+++ b/moniker/src/bound/im.rs
@@ -4,6 +4,7 @@ use super::*;
 
 impl<N, T> BoundTerm<N> for Vector<T>
 where
+    N: Clone + PartialEq,
     T: Clone + BoundTerm<N>,
 {
     fn term_eq(&self, other: &Vector<T>) -> bool {
@@ -11,15 +12,15 @@ where
             && <_>::zip(self.iter(), other.iter()).all(|(lhs, rhs)| T::term_eq(lhs, rhs))
     }
 
-    fn close_term(&mut self, state: ScopeState, binders: &[Binder<N>]) {
+    fn close_term(&mut self, state: ScopeState, on_free: &impl OnFreeFn<N>) {
         for elem in self.iter_mut() {
-            elem.close_term(state, binders);
+            elem.close_term(state, on_free);
         }
     }
 
-    fn open_term(&mut self, state: ScopeState, binders: &[Binder<N>]) {
+    fn open_term(&mut self, state: ScopeState, on_bound: &impl OnBoundFn<N>) {
         for elem in self.iter_mut() {
-            elem.open_term(state, binders);
+            elem.open_term(state, on_bound);
         }
     }
 
@@ -38,7 +39,7 @@ where
 
 impl<N, P> BoundPattern<N> for Vector<P>
 where
-    N: Clone,
+    N: Clone + PartialEq,
     P: Clone + BoundPattern<N>,
 {
     fn pattern_eq(&self, other: &Vector<P>) -> bool {
@@ -46,15 +47,15 @@ where
             && <_>::zip(self.iter(), other.iter()).all(|(lhs, rhs)| P::pattern_eq(lhs, rhs))
     }
 
-    fn close_pattern(&mut self, state: ScopeState, binders: &[Binder<N>]) {
+    fn close_pattern(&mut self, state: ScopeState, on_free: &impl OnFreeFn<N>) {
         for elem in self.iter_mut() {
-            elem.close_pattern(state, binders);
+            elem.close_pattern(state, on_free);
         }
     }
 
-    fn open_pattern(&mut self, state: ScopeState, binders: &[Binder<N>]) {
+    fn open_pattern(&mut self, state: ScopeState, on_bound: &impl OnBoundFn<N>) {
         for elem in self.iter_mut() {
-            elem.open_pattern(state, binders);
+            elem.open_pattern(state, on_bound);
         }
     }
 

--- a/moniker/src/bound/mod.rs
+++ b/moniker/src/bound/mod.rs
@@ -52,6 +52,17 @@ impl<N: Clone + PartialEq> OnFreeFn<N> for Vec<Binder<N>> {
     }
 }
 
+impl<N: Clone + PartialEq> OnFreeFn<N> for Vec<Vec<Binder<N>>> {
+    fn call(&self, mut state: ScopeState, free_var: &FreeVar<N>) -> Option<BoundVar<N>> {
+        self.iter()
+            .filter_map(|binders| {
+                let result = OnFreeFn::call(binders, state, free_var);
+                state = state.incr();
+                result
+            }).next()
+    }
+}
+
 pub trait OnBoundFn<N> {
     fn call(&self, state: ScopeState, bound_var: &BoundVar<N>) -> Option<FreeVar<N>>;
 }
@@ -72,6 +83,17 @@ impl<N: Clone + PartialEq> OnBoundFn<N> for Vec<Binder<N>> {
         } else {
             None
         }
+    }
+}
+
+impl<N: Clone + PartialEq> OnBoundFn<N> for Vec<Vec<Binder<N>>> {
+    fn call(&self, mut state: ScopeState, bound_var: &BoundVar<N>) -> Option<FreeVar<N>> {
+        self.iter()
+            .filter_map(|binders| {
+                let result = OnBoundFn::call(binders, state, bound_var);
+                state = state.incr();
+                result
+            }).next()
     }
 }
 

--- a/moniker/src/bound/mod.rs
+++ b/moniker/src/bound/mod.rs
@@ -35,16 +35,56 @@ impl ScopeState {
     }
 }
 
+pub trait OnFreeFn<N> {
+    fn call(&self, state: ScopeState, free_var: &FreeVar<N>) -> Option<BoundVar<N>>;
+}
+
+impl<N: Clone + PartialEq> OnFreeFn<N> for Vec<Binder<N>> {
+    fn call(&self, state: ScopeState, free_var: &FreeVar<N>) -> Option<BoundVar<N>> {
+        self.iter()
+            .enumerate()
+            .find(|&(_, ref binder)| *binder == free_var)
+            .map(|(i, _)| BoundVar {
+                scope: state.depth(),
+                binder: BinderIndex(i as u32),
+                pretty_name: free_var.pretty_name.clone(),
+            })
+    }
+}
+
+pub trait OnBoundFn<N> {
+    fn call(&self, state: ScopeState, bound_var: &BoundVar<N>) -> Option<FreeVar<N>>;
+}
+
+impl<N: Clone + PartialEq> OnBoundFn<N> for Vec<Binder<N>> {
+    fn call(&self, state: ScopeState, bound_var: &BoundVar<N>) -> Option<FreeVar<N>> {
+        if bound_var.scope == state.depth() {
+            match self.get(bound_var.binder.to_usize()) {
+                Some(&Binder(ref free_var)) => Some(free_var.clone()),
+                None => {
+                    // FIXME: better error?
+                    panic!(
+                        "too few variables in pattern: expected at least {}",
+                        bound_var.binder,
+                    );
+                },
+            }
+        } else {
+            None
+        }
+    }
+}
+
 /// Terms that may contain variables that can be bound by patterns
-pub trait BoundTerm<N> {
+pub trait BoundTerm<N: Clone + PartialEq> {
     /// Alpha equivalence for terms
     fn term_eq(&self, other: &Self) -> bool;
 
     /// Close the term using the supplied binders
-    fn close_term(&mut self, state: ScopeState, binders: &[Binder<N>]);
+    fn close_term(&mut self, state: ScopeState, on_free: &impl OnFreeFn<N>);
 
     /// Open the term using the supplied binders
-    fn open_term(&mut self, state: ScopeState, binders: &[Binder<N>]);
+    fn open_term(&mut self, state: ScopeState, on_bound: &impl OnBoundFn<N>);
 
     /// Visit each variable in the term, calling the `on_var` callback on each
     /// of them in turn
@@ -70,64 +110,44 @@ pub trait BoundTerm<N> {
     }
 }
 
-impl<N: PartialEq> BoundTerm<N> for FreeVar<N> {
+impl<N: Clone + PartialEq> BoundTerm<N> for FreeVar<N> {
     fn term_eq(&self, other: &FreeVar<N>) -> bool {
         self == other
     }
 
-    fn close_term(&mut self, _: ScopeState, _: &[Binder<N>]) {}
+    fn close_term(&mut self, _: ScopeState, _: &impl OnFreeFn<N>) {}
 
-    fn open_term(&mut self, _: ScopeState, _: &[Binder<N>]) {}
+    fn open_term(&mut self, _: ScopeState, _: &impl OnBoundFn<N>) {}
 
     fn visit_vars(&self, _: &mut impl FnMut(&Var<N>)) {}
 
     fn visit_mut_vars(&mut self, _: &mut impl FnMut(&mut Var<N>)) {}
 }
 
-impl<N: PartialEq + Clone> BoundTerm<N> for Var<N> {
+impl<N: Clone + PartialEq> BoundTerm<N> for Var<N> {
     fn term_eq(&self, other: &Var<N>) -> bool {
         self == other
     }
 
-    fn close_term(&mut self, state: ScopeState, binders: &[Binder<N>]) {
+    fn close_term(&mut self, state: ScopeState, on_free: &impl OnFreeFn<N>) {
         // NOTE: Working around NLL
         *self = match *self {
             Var::Bound(_) => return,
-            Var::Free(ref free_var) => {
-                let binder_index = binders
-                    .iter()
-                    .enumerate()
-                    .find(|&(_, binder)| binder == free_var)
-                    .map(|(i, _)| BinderIndex(i as u32));
-
-                match binder_index {
-                    Some(binder_index) => Var::Bound(BoundVar {
-                        scope: state.depth(),
-                        binder: binder_index,
-                        pretty_name: free_var.pretty_name.clone(),
-                    }),
-                    None => return,
-                }
+            Var::Free(ref free_var) => match on_free.call(state, free_var) {
+                None => return,
+                Some(bound_var) => Var::Bound(bound_var),
             },
         };
     }
 
-    fn open_term(&mut self, state: ScopeState, binders: &[Binder<N>]) {
+    fn open_term(&mut self, state: ScopeState, on_bound: &impl OnBoundFn<N>) {
         // NOTE: Working around NLL
         *self = match *self {
-            Var::Bound(ref bound_var) if bound_var.scope == state.depth() => {
-                match binders.get(bound_var.binder.to_usize()) {
-                    Some(&Binder(ref free_var)) => Var::Free(free_var.clone()),
-                    None => {
-                        // FIXME: better error?
-                        panic!(
-                            "too few variables in pattern: expected at least {}",
-                            bound_var.binder,
-                        );
-                    },
-                }
+            Var::Free(_) => return,
+            Var::Bound(ref bound_var) => match on_bound.call(state, bound_var) {
+                None => return,
+                Some(free_var) => Var::Free(free_var),
             },
-            Var::Bound(_) | Var::Free(_) => return,
         };
     }
 
@@ -144,14 +164,14 @@ impl<N: PartialEq + Clone> BoundTerm<N> for Var<N> {
 
 macro_rules! impl_bound_term_partial_eq {
     ($T:ty) => {
-        impl<N> BoundTerm<N> for $T {
+        impl<N: Clone + PartialEq> BoundTerm<N> for $T {
             fn term_eq(&self, other: &$T) -> bool {
                 self == other
             }
 
-            fn close_term(&mut self, _: ScopeState, _: &[Binder<N>]) {}
+            fn close_term(&mut self, _: ScopeState, _: &impl OnFreeFn<N>) {}
 
-            fn open_term(&mut self, _: ScopeState, _: &[Binder<N>]) {}
+            fn open_term(&mut self, _: ScopeState, _: &impl OnBoundFn<N>) {}
 
             fn visit_vars(&self, _: &mut impl FnMut(&Var<N>)) {}
 
@@ -180,6 +200,7 @@ impl_bound_term_partial_eq!(f64);
 
 impl<N, T> BoundTerm<N> for Option<T>
 where
+    N: Clone + PartialEq,
     T: BoundTerm<N>,
 {
     fn term_eq(&self, other: &Option<T>) -> bool {
@@ -190,15 +211,15 @@ where
         }
     }
 
-    fn close_term(&mut self, state: ScopeState, binders: &[Binder<N>]) {
+    fn close_term(&mut self, state: ScopeState, on_free: &impl OnFreeFn<N>) {
         if let Some(ref mut inner) = *self {
-            inner.close_term(state, binders);
+            inner.close_term(state, on_free);
         }
     }
 
-    fn open_term(&mut self, state: ScopeState, binders: &[Binder<N>]) {
+    fn open_term(&mut self, state: ScopeState, on_bound: &impl OnBoundFn<N>) {
         if let Some(ref mut inner) = *self {
-            inner.open_term(state, binders);
+            inner.open_term(state, on_bound);
         }
     }
 
@@ -217,18 +238,19 @@ where
 
 impl<N, T> BoundTerm<N> for Box<T>
 where
+    N: Clone + PartialEq,
     T: BoundTerm<N>,
 {
     fn term_eq(&self, other: &Box<T>) -> bool {
         T::term_eq(self, other)
     }
 
-    fn close_term(&mut self, state: ScopeState, binders: &[Binder<N>]) {
-        T::close_term(self, state, binders);
+    fn close_term(&mut self, state: ScopeState, on_free: &impl OnFreeFn<N>) {
+        T::close_term(self, state, on_free);
     }
 
-    fn open_term(&mut self, state: ScopeState, binders: &[Binder<N>]) {
-        T::open_term(self, state, binders);
+    fn open_term(&mut self, state: ScopeState, on_bound: &impl OnBoundFn<N>) {
+        T::open_term(self, state, on_bound);
     }
 
     fn visit_vars(&self, on_var: &mut impl FnMut(&Var<N>)) {
@@ -242,18 +264,19 @@ where
 
 impl<N, T> BoundTerm<N> for Rc<T>
 where
+    N: Clone + PartialEq,
     T: BoundTerm<N> + Clone,
 {
     fn term_eq(&self, other: &Rc<T>) -> bool {
         T::term_eq(self, other)
     }
 
-    fn close_term(&mut self, state: ScopeState, binders: &[Binder<N>]) {
-        T::close_term(Rc::make_mut(self), state, binders);
+    fn close_term(&mut self, state: ScopeState, on_free: &impl OnFreeFn<N>) {
+        T::close_term(Rc::make_mut(self), state, on_free);
     }
 
-    fn open_term(&mut self, state: ScopeState, binders: &[Binder<N>]) {
-        T::open_term(Rc::make_mut(self), state, binders);
+    fn open_term(&mut self, state: ScopeState, on_bound: &impl OnBoundFn<N>) {
+        T::open_term(Rc::make_mut(self), state, on_bound);
     }
 
     fn visit_vars(&self, on_var: &mut impl FnMut(&Var<N>)) {
@@ -267,18 +290,19 @@ where
 
 impl<N, T> BoundTerm<N> for Arc<T>
 where
+    N: Clone + PartialEq,
     T: BoundTerm<N> + Clone,
 {
     fn term_eq(&self, other: &Arc<T>) -> bool {
         T::term_eq(self, other)
     }
 
-    fn close_term(&mut self, state: ScopeState, binders: &[Binder<N>]) {
-        T::close_term(Arc::make_mut(self), state, binders);
+    fn close_term(&mut self, state: ScopeState, on_free: &impl OnFreeFn<N>) {
+        T::close_term(Arc::make_mut(self), state, on_free);
     }
 
-    fn open_term(&mut self, state: ScopeState, binders: &[Binder<N>]) {
-        T::open_term(Arc::make_mut(self), state, binders);
+    fn open_term(&mut self, state: ScopeState, on_bound: &impl OnBoundFn<N>) {
+        T::open_term(Arc::make_mut(self), state, on_bound);
     }
 
     fn visit_vars(&self, on_var: &mut impl FnMut(&Var<N>)) {
@@ -292,6 +316,7 @@ where
 
 impl<N, T1, T2> BoundTerm<N> for (T1, T2)
 where
+    N: Clone + PartialEq,
     T1: BoundTerm<N>,
     T2: BoundTerm<N>,
 {
@@ -299,14 +324,14 @@ where
         T1::term_eq(&self.0, &other.0) && T2::term_eq(&self.1, &other.1)
     }
 
-    fn close_term(&mut self, state: ScopeState, binders: &[Binder<N>]) {
-        self.0.close_term(state, binders);
-        self.1.close_term(state, binders);
+    fn close_term(&mut self, state: ScopeState, on_free: &impl OnFreeFn<N>) {
+        self.0.close_term(state, on_free);
+        self.1.close_term(state, on_free);
     }
 
-    fn open_term(&mut self, state: ScopeState, binders: &[Binder<N>]) {
-        self.0.open_term(state, binders);
-        self.1.open_term(state, binders);
+    fn open_term(&mut self, state: ScopeState, on_bound: &impl OnBoundFn<N>) {
+        self.0.open_term(state, on_bound);
+        self.1.open_term(state, on_bound);
     }
 
     fn visit_vars(&self, on_var: &mut impl FnMut(&Var<N>)) {
@@ -322,6 +347,7 @@ where
 
 impl<N, T1, T2, T3> BoundTerm<N> for (T1, T2, T3)
 where
+    N: Clone + PartialEq,
     T1: BoundTerm<N>,
     T2: BoundTerm<N>,
     T3: BoundTerm<N>,
@@ -332,16 +358,16 @@ where
             && T3::term_eq(&self.2, &other.2)
     }
 
-    fn close_term(&mut self, state: ScopeState, binders: &[Binder<N>]) {
-        self.0.close_term(state, binders);
-        self.1.close_term(state, binders);
-        self.2.close_term(state, binders);
+    fn close_term(&mut self, state: ScopeState, on_free: &impl OnFreeFn<N>) {
+        self.0.close_term(state, on_free);
+        self.1.close_term(state, on_free);
+        self.2.close_term(state, on_free);
     }
 
-    fn open_term(&mut self, state: ScopeState, binders: &[Binder<N>]) {
-        self.0.open_term(state, binders);
-        self.1.open_term(state, binders);
-        self.2.open_term(state, binders);
+    fn open_term(&mut self, state: ScopeState, on_bound: &impl OnBoundFn<N>) {
+        self.0.open_term(state, on_bound);
+        self.1.open_term(state, on_bound);
+        self.2.open_term(state, on_bound);
     }
 
     fn visit_vars(&self, on_var: &mut impl FnMut(&Var<N>)) {
@@ -359,6 +385,7 @@ where
 
 impl<N, T1, T2, T3, T4> BoundTerm<N> for (T1, T2, T3, T4)
 where
+    N: Clone + PartialEq,
     T1: BoundTerm<N>,
     T2: BoundTerm<N>,
     T3: BoundTerm<N>,
@@ -371,18 +398,18 @@ where
             && T4::term_eq(&self.3, &other.3)
     }
 
-    fn close_term(&mut self, state: ScopeState, binders: &[Binder<N>]) {
-        self.0.close_term(state, binders);
-        self.1.close_term(state, binders);
-        self.2.close_term(state, binders);
-        self.3.close_term(state, binders);
+    fn close_term(&mut self, state: ScopeState, on_free: &impl OnFreeFn<N>) {
+        self.0.close_term(state, on_free);
+        self.1.close_term(state, on_free);
+        self.2.close_term(state, on_free);
+        self.3.close_term(state, on_free);
     }
 
-    fn open_term(&mut self, state: ScopeState, binders: &[Binder<N>]) {
-        self.0.open_term(state, binders);
-        self.1.open_term(state, binders);
-        self.2.open_term(state, binders);
-        self.3.open_term(state, binders);
+    fn open_term(&mut self, state: ScopeState, on_bound: &impl OnBoundFn<N>) {
+        self.0.open_term(state, on_bound);
+        self.1.open_term(state, on_bound);
+        self.2.open_term(state, on_bound);
+        self.3.open_term(state, on_bound);
     }
 
     fn visit_vars(&self, on_var: &mut impl FnMut(&Var<N>)) {
@@ -402,6 +429,7 @@ where
 
 impl<N, T1, T2, T3, T4, T5> BoundTerm<N> for (T1, T2, T3, T4, T5)
 where
+    N: Clone + PartialEq,
     T1: BoundTerm<N>,
     T2: BoundTerm<N>,
     T3: BoundTerm<N>,
@@ -416,20 +444,20 @@ where
             && T5::term_eq(&self.4, &other.4)
     }
 
-    fn close_term(&mut self, state: ScopeState, binders: &[Binder<N>]) {
-        self.0.close_term(state, binders);
-        self.1.close_term(state, binders);
-        self.2.close_term(state, binders);
-        self.3.close_term(state, binders);
-        self.4.close_term(state, binders);
+    fn close_term(&mut self, state: ScopeState, on_free: &impl OnFreeFn<N>) {
+        self.0.close_term(state, on_free);
+        self.1.close_term(state, on_free);
+        self.2.close_term(state, on_free);
+        self.3.close_term(state, on_free);
+        self.4.close_term(state, on_free);
     }
 
-    fn open_term(&mut self, state: ScopeState, binders: &[Binder<N>]) {
-        self.0.open_term(state, binders);
-        self.1.open_term(state, binders);
-        self.2.open_term(state, binders);
-        self.3.open_term(state, binders);
-        self.4.open_term(state, binders);
+    fn open_term(&mut self, state: ScopeState, on_bound: &impl OnBoundFn<N>) {
+        self.0.open_term(state, on_bound);
+        self.1.open_term(state, on_bound);
+        self.2.open_term(state, on_bound);
+        self.3.open_term(state, on_bound);
+        self.4.open_term(state, on_bound);
     }
 
     fn visit_vars(&self, on_var: &mut impl FnMut(&Var<N>)) {
@@ -451,6 +479,7 @@ where
 
 impl<N, T> BoundTerm<N> for [T]
 where
+    N: Clone + PartialEq,
     T: BoundTerm<N>,
 {
     fn term_eq(&self, other: &[T]) -> bool {
@@ -458,15 +487,15 @@ where
             && <_>::zip(self.iter(), other.iter()).all(|(lhs, rhs)| T::term_eq(lhs, rhs))
     }
 
-    fn close_term(&mut self, state: ScopeState, binders: &[Binder<N>]) {
+    fn close_term(&mut self, state: ScopeState, on_free: &impl OnFreeFn<N>) {
         for elem in self {
-            elem.close_term(state, binders);
+            elem.close_term(state, on_free);
         }
     }
 
-    fn open_term(&mut self, state: ScopeState, binders: &[Binder<N>]) {
+    fn open_term(&mut self, state: ScopeState, on_bound: &impl OnBoundFn<N>) {
         for elem in self {
-            elem.open_term(state, binders);
+            elem.open_term(state, on_bound);
         }
     }
 
@@ -485,18 +514,19 @@ where
 
 impl<N, T> BoundTerm<N> for Vec<T>
 where
+    N: Clone + PartialEq,
     T: BoundTerm<N>,
 {
     fn term_eq(&self, other: &Vec<T>) -> bool {
         <[T]>::term_eq(self, other)
     }
 
-    fn close_term(&mut self, state: ScopeState, binders: &[Binder<N>]) {
-        <[T]>::close_term(self, state, binders)
+    fn close_term(&mut self, state: ScopeState, on_free: &impl OnFreeFn<N>) {
+        <[T]>::close_term(self, state, on_free)
     }
 
-    fn open_term(&mut self, state: ScopeState, binders: &[Binder<N>]) {
-        <[T]>::open_term(self, state, binders)
+    fn open_term(&mut self, state: ScopeState, on_bound: &impl OnBoundFn<N>) {
+        <[T]>::open_term(self, state, on_bound)
     }
 
     fn visit_vars(&self, on_var: &mut impl FnMut(&Var<N>)) {
@@ -509,15 +539,15 @@ where
 }
 
 /// Patterns that bind variables in terms
-pub trait BoundPattern<N> {
+pub trait BoundPattern<N: Clone + PartialEq> {
     /// Alpha equivalence for patterns
     fn pattern_eq(&self, other: &Self) -> bool;
 
     /// Close the terms in the pattern using the supplied binders
-    fn close_pattern(&mut self, state: ScopeState, binders: &[Binder<N>]);
+    fn close_pattern(&mut self, state: ScopeState, on_free: &impl OnFreeFn<N>);
 
     /// Open the terms in the pattern using the supplied binders
-    fn open_pattern(&mut self, state: ScopeState, binders: &[Binder<N>]);
+    fn open_pattern(&mut self, state: ScopeState, on_bound: &impl OnBoundFn<N>);
 
     /// Visit each of the binders in the term, calling the `on_binder` callback
     /// on each of them in turn
@@ -548,9 +578,9 @@ where
         true
     }
 
-    fn close_pattern(&mut self, _: ScopeState, _: &[Binder<N>]) {}
+    fn close_pattern(&mut self, _: ScopeState, _: &impl OnFreeFn<N>) {}
 
-    fn open_pattern(&mut self, _: ScopeState, _: &[Binder<N>]) {}
+    fn open_pattern(&mut self, _: ScopeState, _: &impl OnBoundFn<N>) {}
 
     fn visit_binders(&self, on_binder: &mut impl FnMut(&Binder<N>)) {
         on_binder(self)
@@ -565,14 +595,14 @@ where
 
 macro_rules! impl_bound_pattern_partial_eq {
     ($T:ty) => {
-        impl<N> BoundPattern<N> for $T {
+        impl<N: Clone + PartialEq> BoundPattern<N> for $T {
             fn pattern_eq(&self, other: &$T) -> bool {
                 self == other
             }
 
-            fn close_pattern(&mut self, _: ScopeState, _: &[Binder<N>]) {}
+            fn close_pattern(&mut self, _: ScopeState, _: &impl OnFreeFn<N>) {}
 
-            fn open_pattern(&mut self, _: ScopeState, _: &[Binder<N>]) {}
+            fn open_pattern(&mut self, _: ScopeState, _: &impl OnBoundFn<N>) {}
 
             fn visit_binders(&self, _: &mut impl FnMut(&Binder<N>)) {}
 
@@ -601,6 +631,7 @@ impl_bound_pattern_partial_eq!(f64);
 
 impl<N, P> BoundPattern<N> for Option<P>
 where
+    N: Clone + PartialEq,
     P: BoundPattern<N>,
 {
     fn pattern_eq(&self, other: &Option<P>) -> bool {
@@ -611,15 +642,15 @@ where
         }
     }
 
-    fn close_pattern(&mut self, state: ScopeState, binders: &[Binder<N>]) {
+    fn close_pattern(&mut self, state: ScopeState, on_free: &impl OnFreeFn<N>) {
         if let Some(ref mut inner) = *self {
-            inner.close_pattern(state, binders);
+            inner.close_pattern(state, on_free);
         }
     }
 
-    fn open_pattern(&mut self, state: ScopeState, binders: &[Binder<N>]) {
+    fn open_pattern(&mut self, state: ScopeState, on_bound: &impl OnBoundFn<N>) {
         if let Some(ref mut inner) = *self {
-            inner.open_pattern(state, binders);
+            inner.open_pattern(state, on_bound);
         }
     }
 
@@ -638,6 +669,7 @@ where
 
 impl<N, P1, P2> BoundPattern<N> for (P1, P2)
 where
+    N: Clone + PartialEq,
     P1: BoundPattern<N>,
     P2: BoundPattern<N>,
 {
@@ -645,14 +677,14 @@ where
         P1::pattern_eq(&self.0, &other.0) && P2::pattern_eq(&self.1, &other.1)
     }
 
-    fn close_pattern(&mut self, state: ScopeState, binders: &[Binder<N>]) {
-        self.0.close_pattern(state, binders);
-        self.1.close_pattern(state, binders);
+    fn close_pattern(&mut self, state: ScopeState, on_free: &impl OnFreeFn<N>) {
+        self.0.close_pattern(state, on_free);
+        self.1.close_pattern(state, on_free);
     }
 
-    fn open_pattern(&mut self, state: ScopeState, binders: &[Binder<N>]) {
-        self.0.open_pattern(state, binders);
-        self.1.open_pattern(state, binders);
+    fn open_pattern(&mut self, state: ScopeState, on_bound: &impl OnBoundFn<N>) {
+        self.0.open_pattern(state, on_bound);
+        self.1.open_pattern(state, on_bound);
     }
 
     fn visit_binders(&self, on_binder: &mut impl FnMut(&Binder<N>)) {
@@ -668,6 +700,7 @@ where
 
 impl<N, P1, P2, P3> BoundPattern<N> for (P1, P2, P3)
 where
+    N: Clone + PartialEq,
     P1: BoundPattern<N>,
     P2: BoundPattern<N>,
     P3: BoundPattern<N>,
@@ -678,16 +711,16 @@ where
             && P3::pattern_eq(&self.2, &other.2)
     }
 
-    fn close_pattern(&mut self, state: ScopeState, binders: &[Binder<N>]) {
-        self.0.close_pattern(state, binders);
-        self.1.close_pattern(state, binders);
-        self.2.close_pattern(state, binders);
+    fn close_pattern(&mut self, state: ScopeState, on_free: &impl OnFreeFn<N>) {
+        self.0.close_pattern(state, on_free);
+        self.1.close_pattern(state, on_free);
+        self.2.close_pattern(state, on_free);
     }
 
-    fn open_pattern(&mut self, state: ScopeState, binders: &[Binder<N>]) {
-        self.0.open_pattern(state, binders);
-        self.1.open_pattern(state, binders);
-        self.2.open_pattern(state, binders);
+    fn open_pattern(&mut self, state: ScopeState, on_bound: &impl OnBoundFn<N>) {
+        self.0.open_pattern(state, on_bound);
+        self.1.open_pattern(state, on_bound);
+        self.2.open_pattern(state, on_bound);
     }
 
     fn visit_binders(&self, on_binder: &mut impl FnMut(&Binder<N>)) {
@@ -705,6 +738,7 @@ where
 
 impl<N, P1, P2, P3, P4> BoundPattern<N> for (P1, P2, P3, P4)
 where
+    N: Clone + PartialEq,
     P1: BoundPattern<N>,
     P2: BoundPattern<N>,
     P3: BoundPattern<N>,
@@ -717,18 +751,18 @@ where
             && P4::pattern_eq(&self.3, &other.3)
     }
 
-    fn close_pattern(&mut self, state: ScopeState, binders: &[Binder<N>]) {
-        self.0.close_pattern(state, binders);
-        self.1.close_pattern(state, binders);
-        self.2.close_pattern(state, binders);
-        self.3.close_pattern(state, binders);
+    fn close_pattern(&mut self, state: ScopeState, on_free: &impl OnFreeFn<N>) {
+        self.0.close_pattern(state, on_free);
+        self.1.close_pattern(state, on_free);
+        self.2.close_pattern(state, on_free);
+        self.3.close_pattern(state, on_free);
     }
 
-    fn open_pattern(&mut self, state: ScopeState, binders: &[Binder<N>]) {
-        self.0.open_pattern(state, binders);
-        self.1.open_pattern(state, binders);
-        self.2.open_pattern(state, binders);
-        self.3.open_pattern(state, binders);
+    fn open_pattern(&mut self, state: ScopeState, on_bound: &impl OnBoundFn<N>) {
+        self.0.open_pattern(state, on_bound);
+        self.1.open_pattern(state, on_bound);
+        self.2.open_pattern(state, on_bound);
+        self.3.open_pattern(state, on_bound);
     }
 
     fn visit_binders(&self, on_binder: &mut impl FnMut(&Binder<N>)) {
@@ -748,6 +782,7 @@ where
 
 impl<N, P1, P2, P3, P4, P5> BoundPattern<N> for (P1, P2, P3, P4, P5)
 where
+    N: Clone + PartialEq,
     P1: BoundPattern<N>,
     P2: BoundPattern<N>,
     P3: BoundPattern<N>,
@@ -762,20 +797,20 @@ where
             && P5::pattern_eq(&self.4, &other.4)
     }
 
-    fn close_pattern(&mut self, state: ScopeState, binders: &[Binder<N>]) {
-        self.0.close_pattern(state, binders);
-        self.1.close_pattern(state, binders);
-        self.2.close_pattern(state, binders);
-        self.3.close_pattern(state, binders);
-        self.4.close_pattern(state, binders);
+    fn close_pattern(&mut self, state: ScopeState, on_free: &impl OnFreeFn<N>) {
+        self.0.close_pattern(state, on_free);
+        self.1.close_pattern(state, on_free);
+        self.2.close_pattern(state, on_free);
+        self.3.close_pattern(state, on_free);
+        self.4.close_pattern(state, on_free);
     }
 
-    fn open_pattern(&mut self, state: ScopeState, binders: &[Binder<N>]) {
-        self.0.open_pattern(state, binders);
-        self.1.open_pattern(state, binders);
-        self.2.open_pattern(state, binders);
-        self.3.open_pattern(state, binders);
-        self.4.open_pattern(state, binders);
+    fn open_pattern(&mut self, state: ScopeState, on_bound: &impl OnBoundFn<N>) {
+        self.0.open_pattern(state, on_bound);
+        self.1.open_pattern(state, on_bound);
+        self.2.open_pattern(state, on_bound);
+        self.3.open_pattern(state, on_bound);
+        self.4.open_pattern(state, on_bound);
     }
 
     fn visit_binders(&self, on_binder: &mut impl FnMut(&Binder<N>)) {
@@ -797,18 +832,19 @@ where
 
 impl<N, P> BoundPattern<N> for Box<P>
 where
+    N: Clone + PartialEq,
     P: BoundPattern<N>,
 {
     fn pattern_eq(&self, other: &Box<P>) -> bool {
         P::pattern_eq(self, other)
     }
 
-    fn close_pattern(&mut self, state: ScopeState, binders: &[Binder<N>]) {
-        P::close_pattern(self, state, binders);
+    fn close_pattern(&mut self, state: ScopeState, on_free: &impl OnFreeFn<N>) {
+        P::close_pattern(self, state, on_free);
     }
 
-    fn open_pattern(&mut self, state: ScopeState, binders: &[Binder<N>]) {
-        P::open_pattern(self, state, binders);
+    fn open_pattern(&mut self, state: ScopeState, on_bound: &impl OnBoundFn<N>) {
+        P::open_pattern(self, state, on_bound);
     }
 
     fn visit_binders(&self, on_binder: &mut impl FnMut(&Binder<N>)) {
@@ -822,18 +858,19 @@ where
 
 impl<N, P> BoundPattern<N> for Rc<P>
 where
+    N: Clone + PartialEq,
     P: BoundPattern<N> + Clone,
 {
     fn pattern_eq(&self, other: &Rc<P>) -> bool {
         P::pattern_eq(self, other)
     }
 
-    fn close_pattern(&mut self, state: ScopeState, binders: &[Binder<N>]) {
-        P::close_pattern(Rc::make_mut(self), state, binders);
+    fn close_pattern(&mut self, state: ScopeState, on_free: &impl OnFreeFn<N>) {
+        P::close_pattern(Rc::make_mut(self), state, on_free);
     }
 
-    fn open_pattern(&mut self, state: ScopeState, binders: &[Binder<N>]) {
-        P::open_pattern(Rc::make_mut(self), state, binders);
+    fn open_pattern(&mut self, state: ScopeState, on_bound: &impl OnBoundFn<N>) {
+        P::open_pattern(Rc::make_mut(self), state, on_bound);
     }
 
     fn visit_binders(&self, on_binder: &mut impl FnMut(&Binder<N>)) {
@@ -847,18 +884,19 @@ where
 
 impl<N, P> BoundPattern<N> for Arc<P>
 where
+    N: Clone + PartialEq,
     P: BoundPattern<N> + Clone,
 {
     fn pattern_eq(&self, other: &Arc<P>) -> bool {
         P::pattern_eq(self, other)
     }
 
-    fn close_pattern(&mut self, state: ScopeState, binders: &[Binder<N>]) {
-        P::close_pattern(Arc::make_mut(self), state, binders);
+    fn close_pattern(&mut self, state: ScopeState, on_free: &impl OnFreeFn<N>) {
+        P::close_pattern(Arc::make_mut(self), state, on_free);
     }
 
-    fn open_pattern(&mut self, state: ScopeState, binders: &[Binder<N>]) {
-        P::open_pattern(Arc::make_mut(self), state, binders);
+    fn open_pattern(&mut self, state: ScopeState, on_bound: &impl OnBoundFn<N>) {
+        P::open_pattern(Arc::make_mut(self), state, on_bound);
     }
 
     fn visit_binders(&self, on_binder: &mut impl FnMut(&Binder<N>)) {
@@ -872,6 +910,7 @@ where
 
 impl<N, P> BoundPattern<N> for [P]
 where
+    N: Clone + PartialEq,
     N: Clone,
     P: BoundPattern<N>,
 {
@@ -880,15 +919,15 @@ where
             && <_>::zip(self.iter(), other.iter()).all(|(lhs, rhs)| P::pattern_eq(lhs, rhs))
     }
 
-    fn close_pattern(&mut self, state: ScopeState, binders: &[Binder<N>]) {
+    fn close_pattern(&mut self, state: ScopeState, on_free: &impl OnFreeFn<N>) {
         for elem in self {
-            elem.close_pattern(state, binders);
+            elem.close_pattern(state, on_free);
         }
     }
 
-    fn open_pattern(&mut self, state: ScopeState, binders: &[Binder<N>]) {
+    fn open_pattern(&mut self, state: ScopeState, on_bound: &impl OnBoundFn<N>) {
         for elem in self {
-            elem.open_pattern(state, binders);
+            elem.open_pattern(state, on_bound);
         }
     }
 
@@ -907,19 +946,19 @@ where
 
 impl<N, P> BoundPattern<N> for Vec<P>
 where
-    N: Clone,
+    N: Clone + PartialEq,
     P: BoundPattern<N>,
 {
     fn pattern_eq(&self, other: &Vec<P>) -> bool {
         <[P]>::pattern_eq(self, other)
     }
 
-    fn close_pattern(&mut self, state: ScopeState, binders: &[Binder<N>]) {
-        <[P]>::close_pattern(self, state, binders);
+    fn close_pattern(&mut self, state: ScopeState, on_free: &impl OnFreeFn<N>) {
+        <[P]>::close_pattern(self, state, on_free);
     }
 
-    fn open_pattern(&mut self, state: ScopeState, binders: &[Binder<N>]) {
-        <[P]>::open_pattern(self, state, binders);
+    fn open_pattern(&mut self, state: ScopeState, on_bound: &impl OnBoundFn<N>) {
+        <[P]>::open_pattern(self, state, on_bound);
     }
 
     fn visit_binders(&self, on_binder: &mut impl FnMut(&Binder<N>)) {

--- a/moniker/src/bound/num_bigint.rs
+++ b/moniker/src/bound/num_bigint.rs
@@ -4,14 +4,14 @@ use super::*;
 
 macro_rules! impl_bound_term_partial_eq {
     ($T:ty) => {
-        impl<N> BoundTerm<N> for $T {
+        impl<N: Clone + PartialEq> BoundTerm<N> for $T {
             fn term_eq(&self, other: &$T) -> bool {
                 self == other
             }
 
-            fn close_term(&mut self, _: ScopeState, _: &[Binder<N>]) {}
+            fn close_term(&mut self, _: ScopeState, _: &impl OnFreeFn<N>) {}
 
-            fn open_term(&mut self, _: ScopeState, _: &[Binder<N>]) {}
+            fn open_term(&mut self, _: ScopeState, _: &impl OnBoundFn<N>) {}
 
             fn visit_vars(&self, _: &mut impl FnMut(&Var<N>)) {}
 
@@ -25,14 +25,14 @@ impl_bound_term_partial_eq!(BigUint);
 
 macro_rules! impl_bound_pattern_partial_eq {
     ($T:ty) => {
-        impl<N> BoundPattern<N> for $T {
+        impl<N: Clone + PartialEq> BoundPattern<N> for $T {
             fn pattern_eq(&self, other: &$T) -> bool {
                 self == other
             }
 
-            fn close_pattern(&mut self, _: ScopeState, _: &[Binder<N>]) {}
+            fn close_pattern(&mut self, _: ScopeState, _: &impl OnFreeFn<N>) {}
 
-            fn open_pattern(&mut self, _: ScopeState, _: &[Binder<N>]) {}
+            fn open_pattern(&mut self, _: ScopeState, _: &impl OnBoundFn<N>) {}
 
             fn visit_binders(&self, _: &mut impl FnMut(&Binder<N>)) {}
 

--- a/moniker/src/embed.rs
+++ b/moniker/src/embed.rs
@@ -1,5 +1,5 @@
 use binder::Binder;
-use bound::{BoundPattern, BoundTerm, ScopeState};
+use bound::{BoundPattern, BoundTerm, OnBoundFn, OnFreeFn, ScopeState};
 
 /// Embed a term in a pattern
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -7,18 +7,19 @@ pub struct Embed<T>(pub T);
 
 impl<N, T> BoundPattern<N> for Embed<T>
 where
+    N: Clone + PartialEq,
     T: BoundTerm<N>,
 {
     fn pattern_eq(&self, other: &Embed<T>) -> bool {
         T::term_eq(&self.0, &other.0)
     }
 
-    fn close_pattern(&mut self, state: ScopeState, binders: &[Binder<N>]) {
-        self.0.close_term(state, binders);
+    fn close_pattern(&mut self, state: ScopeState, on_free: &impl OnFreeFn<N>) {
+        self.0.close_term(state, on_free);
     }
 
-    fn open_pattern(&mut self, state: ScopeState, binders: &[Binder<N>]) {
-        self.0.open_term(state, binders);
+    fn open_pattern(&mut self, state: ScopeState, on_bound: &impl OnBoundFn<N>) {
+        self.0.open_term(state, on_bound);
     }
 
     fn visit_binders(&self, _: &mut impl FnMut(&Binder<N>)) {}

--- a/moniker/src/ignore.rs
+++ b/moniker/src/ignore.rs
@@ -1,5 +1,5 @@
 use binder::Binder;
-use bound::{BoundPattern, BoundTerm, ScopeState};
+use bound::{BoundPattern, BoundTerm, OnBoundFn, OnFreeFn, ScopeState};
 use var::Var;
 
 /// Data that does not participate in name binding
@@ -9,28 +9,34 @@ use var::Var;
 #[derive(Debug, Copy, Clone, PartialEq, Eq, Hash, Default)]
 pub struct Ignore<T>(pub T);
 
-impl<N, T> BoundTerm<N> for Ignore<T> {
+impl<N, T> BoundTerm<N> for Ignore<T>
+where
+    N: Clone + PartialEq,
+{
     fn term_eq(&self, _: &Ignore<T>) -> bool {
         true
     }
 
-    fn close_term(&mut self, _: ScopeState, _: &[Binder<N>]) {}
+    fn close_term(&mut self, _: ScopeState, _: &impl OnFreeFn<N>) {}
 
-    fn open_term(&mut self, _: ScopeState, _: &[Binder<N>]) {}
+    fn open_term(&mut self, _: ScopeState, _: &impl OnBoundFn<N>) {}
 
     fn visit_vars(&self, _: &mut impl FnMut(&Var<N>)) {}
 
     fn visit_mut_vars(&mut self, _: &mut impl FnMut(&mut Var<N>)) {}
 }
 
-impl<N, T> BoundPattern<N> for Ignore<T> {
+impl<N, T> BoundPattern<N> for Ignore<T>
+where
+    N: Clone + PartialEq,
+{
     fn pattern_eq(&self, _: &Ignore<T>) -> bool {
         true
     }
 
-    fn close_pattern(&mut self, _: ScopeState, _: &[Binder<N>]) {}
+    fn close_pattern(&mut self, _: ScopeState, _: &impl OnFreeFn<N>) {}
 
-    fn open_pattern(&mut self, _: ScopeState, _: &[Binder<N>]) {}
+    fn open_pattern(&mut self, _: ScopeState, _: &impl OnBoundFn<N>) {}
 
     fn visit_binders(&self, _: &mut impl FnMut(&Binder<N>)) {}
 

--- a/moniker/src/lib.rs
+++ b/moniker/src/lib.rs
@@ -108,7 +108,7 @@ mod unique_id;
 mod var;
 
 pub use self::binder::Binder;
-pub use self::bound::{BoundPattern, BoundTerm, ScopeState};
+pub use self::bound::{BoundPattern, BoundTerm, OnBoundFn, OnFreeFn, ScopeState};
 pub use self::bound_var::{BinderIndex, BoundVar, ScopeOffset};
 pub use self::embed::Embed;
 pub use self::free_var::FreeVar;


### PR DESCRIPTION
I've been noticing Pikelet's prelude starting to get a little slow, so I've done a little optimization work to reduce some of the re-traversals we do on the `Nest` type. There's still more we can do (see #10 and #21), but it's a start!